### PR TITLE
Close session without waiting for <Enter> if process terminates with SIGHUP or exit status 129

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -73,6 +73,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -860,19 +861,14 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
     }
 
     public void removeFinishedSession(TerminalSession finishedSession) {
-        TermuxService service = mTermService;
+        int index = mTermService.removeTermSession(finishedSession);
+        List<TerminalSession> remainingSessions = mTermService.getSessions();
 
-        int index = service.removeTermSession(finishedSession);
         mListViewAdapter.notifyDataSetChanged();
-        if (mTermService.getSessions().isEmpty()) {
-            // There are no sessions to show, so finish the activity.
+        if (remainingSessions.isEmpty())
             finish();
-        } else {
-            if (index >= service.getSessions().size()) {
-                index = service.getSessions().size() - 1;
-            }
-            switchToSession(service.getSessions().get(index));
-        }
+        else
+            switchToSession(remainingSessions.get(Math.min(index, remainingSessions.size() - 1)));
     }
 
 }

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -393,6 +393,11 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
             }
 
             @Override
+            public void onSessionClosingItself(TerminalSession session) {
+                removeFinishedSession(session);
+            }
+
+            @Override
             public void onClipboardText(TerminalSession session, String text) {
                 if (!mIsVisible) return;
                 showToast("Clipboard:\n\"" + text + "\"", false);
@@ -855,7 +860,6 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
     }
 
     public void removeFinishedSession(TerminalSession finishedSession) {
-        // Return pressed with finished session - remove it.
         TermuxService service = mTermService;
 
         int index = service.removeTermSession(finishedSession);

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -323,6 +323,12 @@ public final class TermuxService extends Service implements SessionChangedCallba
     }
 
     @Override
+    public void onSessionClosingItself(TerminalSession session) {
+        if (mSessionChangeCallback != null)
+            mSessionChangeCallback.onSessionClosingItself(session);
+    }
+
+    @Override
     public void onTextChanged(TerminalSession changedSession) {
         if (mSessionChangeCallback != null) mSessionChangeCallback.onTextChanged(changedSession);
     }


### PR DESCRIPTION
See https://github.com/termux/termux-app/issues/56#issuecomment-218978463

I added the exit status 129 check because Marshmallow /system/bin/sh seems to violate  http://pubs.opengroup.org/onlinepubs/9699919799/utilities/sh.html#tag_20_117_09 (by catching the signal and acting as if the last child process had received it).

Fixes #56
