### PR TITLE
Make ExtraKeysView work on Android 5

### DIFF
--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -165,8 +165,8 @@ public final class ExtraKeysView extends GridLayout {
                 param.rightMargin = param.topMargin = 0;
                 param.setGravity(Gravity.LEFT);
                 float weight = "▲▼◀▶".contains(buttonText) ? 0.7f : 1.f;
-                param.columnSpec = GridLayout.spec(col, weight);
-                param.rowSpec = GridLayout.spec(row, 1.f);
+                param.columnSpec = GridLayout.spec(col, GridLayout.FILL, weight);
+                param.rowSpec = GridLayout.spec(row, GridLayout.FILL, 1.f);
                 button.setLayoutParams(param);
 
                 addView(button);


### PR DESCRIPTION
On Android 5 ExtraKeysView shows empty (though can be swiped for TextView).

This is fixed by explicitly specifying alignment as GridLayout.FILL

I have figured out that this was fixed in Android 6 in commit
https://android.googlesource.com/platform/frameworks/base/+/6dafd87fb4174447018b044bc67818d54fab57d8%5E%21/#F0
which set default alignment to FILL if weight is nonzero