### PR TITLE
Android N multi-window support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,8 +23,8 @@
 
         <activity
             android:name="com.termux.app.TermuxActivity"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-            android:launchMode="singleTask"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout"
+            android:launchMode="standard"
             android:windowSoftInputMode="adjustResize|stateAlwaysVisible" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/termux/app/TermuxKeyListener.java
+++ b/app/src/main/java/com/termux/app/TermuxKeyListener.java
@@ -84,6 +84,8 @@ public final class TermuxKeyListener implements TerminalKeyListener {
                 mActivity.renameSession(currentSession);
             } else if (unicodeChar == 'c'/* create */) {
                 mActivity.addNewSession(false, null);
+            } else if (unicodeChar == 'w'/* window */) {
+                mActivity.addNewWindow();
             } else if (unicodeChar == 'u' /* urls */) {
                 mActivity.showUrlSelection();
             } else if (unicodeChar == 'v') {

--- a/app/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/app/src/main/java/com/termux/terminal/TerminalSession.java
@@ -36,7 +36,13 @@ public final class TerminalSession extends TerminalOutput {
 
         void onTitleChanged(TerminalSession changedSession);
 
+        void onSessionCreated(TerminalSession createdSession);
+
         void onSessionFinished(TerminalSession finishedSession);
+
+        void onSessionRemoved(TerminalSession removedSession);
+
+        void onSessionRenamed(TerminalSession renamedSession);
 
         void onClipboardText(TerminalSession session, String text);
 
@@ -44,6 +50,9 @@ public final class TerminalSession extends TerminalOutput {
 
         void onColorsChanged(TerminalSession session);
 
+        void onAttach(TerminalSession attachedSession);
+
+        void onDetach(TerminalSession detachedSession);
     }
 
     private static FileDescriptor wrapFileDescriptor(int fileDescriptor) {
@@ -103,6 +112,8 @@ public final class TerminalSession extends TerminalOutput {
     /** Set by the application for user identification of session, not by terminal. */
     public String mSessionName;
 
+    public boolean mAttached;
+
     @SuppressLint("HandlerLeak")
     final Handler mMainThreadHandler = new Handler() {
         final byte[] mReceiveBuffer = new byte[4 * 1024];
@@ -149,6 +160,8 @@ public final class TerminalSession extends TerminalOutput {
         this.mCwd = cwd;
         this.mArgs = args;
         this.mEnv = env;
+
+        mChangeCallback.onSessionCreated(this);
     }
 
     /** Inform the attached pty of the new size and reflow or initialize the emulator. */

--- a/app/src/main/java/com/termux/view/TerminalView.java
+++ b/app/src/main/java/com/termux/view/TerminalView.java
@@ -215,7 +215,9 @@ public final class TerminalView extends View {
         if (session == mTermSession) return false;
         mTopRow = 0;
 
+        if (mTermSession != null) mTermSession.mAttached = false;
         mTermSession = session;
+        session.mAttached = true;
         mEmulator = null;
         mCombiningAccent = 0;
 

--- a/app/src/main/res/drawable/selected_session_background.xml
+++ b/app/src/main/res/drawable/selected_session_background.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:drawable="@drawable/session_disabled"/>
     <item android:state_activated="true" android:drawable="@drawable/current_session"/>
     <item android:state_activated="false" android:drawable="@drawable/session_ripple"/>
 </selector>

--- a/app/src/main/res/drawable/session_disabled.xml
+++ b/app/src/main/res/drawable/session_disabled.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@android:color/darker_gray" />
+</shape>

--- a/app/src/main/res/layout/drawer_layout.xml
+++ b/app/src/main/res/layout/drawer_layout.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -37,13 +38,16 @@
                 android:layout_gravity="top"
                 android:layout_weight="1"
                 android:choiceMode="singleChoice"
-                android:longClickable="true" />
+                android:longClickable="true"
+                android:divider="@null"
+                android:dividerHeight="0dp" />
 
             <LinearLayout
                 style="?android:attr/buttonBarStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:orientation="vertical"
+                android:id="@+id/drawer_buttons">
 
                 <Button
                     android:id="@+id/toggle_keyboard_button"
@@ -60,6 +64,16 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="@string/new_session" />
+
+                <Button
+                    android:text="@string/new_window"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/new_window_button"
+                    android:visibility="gone"
+                    android:layout_weight="1" />
+
             </LinearLayout>
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
    <string name="new_session">New session</string>
    <string name="new_session_failsafe">Failsafe</string>
    <string name="toggle_soft_keyboard">Keyboard</string>
+   <string name="new_window">New window</string>
    <string name="reset_terminal">Reset</string>
    <string name="style_terminal">Style</string>
    <string name="toggle_fullscreen">Fullscreen</string>


### PR DESCRIPTION
This PR adds full multi-window support for Android 7.0+.

As soon as the framework enters multi-window mode a new button "New window" (keyboard shortcut Ctrl+Alt+W) becomes visible in the drawer menu. Clicking the button will create a new window. Terminal sessions are shared between windows, however, only one terminal window may attach to a specific session at a time. When creating a new window, the first unattached session will be attached to the new window. If no unattached sessions are available, a new session will be created.

Some screenshots of Termux running in multi-window mode on Android 7.1.1:
![screenshot_1478367704](https://cloud.githubusercontent.com/assets/1225211/20032461/ab02a302-a38a-11e6-9e1c-db09b7a6f8cf.png)
(split-screen)

![screenshot_1478368051](https://cloud.githubusercontent.com/assets/1225211/20032462/b1049f30-a38a-11e6-82d0-26728d18c52e.png)
(freeform mode)

In the second screenshot, for example, the left window may not be attached to session 2 and 3, since they are already attached to the other windows. Any window can switch to session 4.