### PR TITLE
Move more parts to external storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.termux"
-    android:installLocation="internalOnly"
+    android:installLocation="preferExternal"
     android:sharedUserId="com.termux"
     android:sharedUserLabel="@string/shared_user_label" >
 
@@ -9,6 +9,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
 


### PR DESCRIPTION
Allow Termux to be installed on external storage, and extend permission to read_external_storage, as advised here:
https://developer.android.com/training/basics/data-storage/files.html