### PR TITLE
Fix FC from too many control code parameters

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -632,6 +632,7 @@ public final class TerminalEmulator {
                                 int bottom = Math.min(getArg(2, mRows, true) + 1, effectiveBottomMargin - 1) + effectiveTopMargin;
                                 int right = Math.min(getArg(3, mColumns, true) + 1, effectiveRightMargin - 1) + effectiveLeftMargin;
                                 if (mArgIndex >= 4) {
+                                    if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
                                     for (int i = 4; i <= mArgIndex; i++) {
                                         int bits = 0;
                                         boolean setOrClear = true; // True if setting, false if clearing.
@@ -965,6 +966,7 @@ public final class TerminalEmulator {
                 break;
             case 'h':
             case 'l':
+                if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
                 for (int i = 0; i <= mArgIndex; i++)
                     doDecSetOrReset(b == 'h', mArgs[i]);
                 break;
@@ -981,6 +983,7 @@ public final class TerminalEmulator {
                 break;
             case 'r':
             case 's':
+                if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
                 for (int i = 0; i <= mArgIndex; i++) {
                     int externalBit = mArgs[i];
                     int internalBit = mapDecSetBitToInternalBit(externalBit);
@@ -1639,6 +1642,7 @@ public final class TerminalEmulator {
 
     /** Select Graphic Rendition (SGR) - see http://en.wikipedia.org/wiki/ANSI_escape_code#graphics. */
     private void selectGraphicRendition() {
+        if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
         for (int i = 0; i <= mArgIndex; i++) {
             int code = mArgs[i];
             if (code < 0) {
@@ -2049,6 +2053,7 @@ public final class TerminalEmulator {
             buf.append(", escapeState=");
             buf.append(mEscapeState);
             boolean firstArg = true;
+            if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
             for (int i = 0; i <= mArgIndex; i++) {
                 int value = mArgs[i];
                 if (value >= 0) {

--- a/terminal-emulator/src/test/java/com/termux/terminal/ControlSequenceIntroducerTest.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/ControlSequenceIntroducerTest.java
@@ -29,4 +29,10 @@ public class ControlSequenceIntroducerTest extends TerminalTestCase {
 		withTerminalSized(13, 2).enterString("abcdefghijkl\b\b\b\b\b\033[20X").assertLinesAre("abcdefg      ", "             ");
 	}
 
+	/** CSI Pm m  Set SGR parameter(s) from semicolon-separated list Pm. */
+	public void testCsiSGRParameters() {
+		// Set more parameters (19) than supported (16).  Additional parameters should be silently consumed.
+		withTerminalSized(3, 2).enterString("\033[0;38;2;255;255;255;48;2;0;0;0;1;2;3;4;5;7;8;9mabc").assertLinesAre("abc", "   ");
+	}
+
 }


### PR DESCRIPTION
When the number of parameters in a CSI control code exceeds the size of
the mArgs array, the code may attempt to read past the end of the array,
resulting in a force close of the app.
    
Stop the index from moving past the last element of the mArgs array.
