### PR TITLE
Add Multi Window support for Samsung devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,6 +99,7 @@
                   android:grantUriPermissions="true"
                   android:name="com.termux.app.TermuxOpenReceiver$ContentProvider" />
 
+        <meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
A single meta-data entry is enough to make Termux "Multi Window" aware on supported Samsung devices.
Tested and confirmed working on Samsung Note Pro 12.2 running Android 5.1.1.
![screenshot_2017-06-12-01-22-28](https://user-images.githubusercontent.com/43441/27023950-03b6a4e8-4f12-11e7-975a-a09053c5326a.png)

This addition should not interfere with Android 6+'s split screen feature.
Tested and confirmed split screen functions as normal on a Nexus 6 running Android 7.0.

This addition should go unnoticed on non-Smasung Android 5 devices.
Tested and confirmed no functionality visible on Nexus 5 running Android 5.1.