### PR TITLE
Basic accessibility support for the terminal view

### DIFF
--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -15,6 +15,7 @@ import android.text.InputType;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.accessibility.AccessibilityManager;
 import android.view.ActionMode;
 import android.view.HapticFeedbackConstants;
 import android.view.InputDevice;
@@ -74,6 +75,8 @@ public final class TerminalView extends View {
 
     /** If non-zero, this is the last unicode code point received if that was a combining character. */
     int mCombiningAccent;
+
+    private boolean mAccessibilityEnabled;
 
     public TerminalView(Context context, AttributeSet attributes) { // NO_UCD (unused code)
         super(context, attributes);
@@ -197,6 +200,8 @@ public final class TerminalView extends View {
             }
         });
         mScroller = new Scroller(context);
+        AccessibilityManager am = (AccessibilityManager) context.getSystemService(context.ACCESSIBILITY_SERVICE);
+        mAccessibilityEnabled = am.isEnabled();
     }
 
     /**
@@ -384,7 +389,7 @@ public final class TerminalView extends View {
         mEmulator.clearScrollCounter();
 
         invalidate();
-        setContentDescription(getText());
+        if (mAccessibilityEnabled) setContentDescription(getText());
     }
 
     /**

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -759,6 +759,7 @@ public final class TerminalView extends View {
         if (mEmulator == null) {
             canvas.drawColor(0XFF000000);
         } else {
+            setContentDescription(getText());
             mRenderer.render(mEmulator, canvas, mTopRow, mSelY1, mSelY2, mSelX1, mSelX2);
 
             if (mIsSelectingText) {
@@ -907,6 +908,10 @@ public final class TerminalView extends View {
 
     public TerminalSession getCurrentSession() {
         return mTermSession;
+    }
+
+    private CharSequence getText() {
+        return mEmulator.getScreen().getSelectedText(0, mTopRow, mEmulator.mColumns, mTopRow +mEmulator.mRows);
     }
 
 }

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -384,6 +384,7 @@ public final class TerminalView extends View {
         mEmulator.clearScrollCounter();
 
         invalidate();
+        setContentDescription(getText());
     }
 
     /**
@@ -759,7 +760,6 @@ public final class TerminalView extends View {
         if (mEmulator == null) {
             canvas.drawColor(0XFF000000);
         } else {
-            setContentDescription(getText());
             mRenderer.render(mEmulator, canvas, mTopRow, mSelY1, mSelY2, mSelX1, mSelX2);
 
             if (mIsSelectingText) {


### PR DESCRIPTION
Terminal view as implemented in the termux app is a view resembling terminal windows known from computers. It's designed to be efficient however for me and other people who are using accessibility services such as Google Talkback to access their android devices it's not very usable. By adding contentDescription property to the view dynamically as it repaints, we can get at least very basic accessibility support.
When using termux on Android with Talkback running it is possible to review currently visible text on the screen by characters, by words and by lines.
It is possible to use two finger scrolling (android built-in feature) to scroll the view and access other parts of the text.
I'm using this for a few months already and I have got some friends interested in this functionality so I'm submitting this as a pull request.
I know it's very minimalistic, but even in its current limited form it's a life changing feature for tech savvy blind people so hopefully you can accept it and / or point out how I might be able to enhance it so everyone can benefit.