### PR TITLE
Add Dual Window support for LG devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -112,6 +112,7 @@
                   android:name="com.termux.app.TermuxOpenReceiver$ContentProvider" />
 
         <meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />
+        <meta-data android:name="com.lge.support.SPLIT_WINDOW" android:value="true"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
Similar to pull request #339.

A single meta-data entry is enough to make Termux "Dual Window" aware on supported LG devices.

![screenshot_2017-07-13-15-14-11](https://user-images.githubusercontent.com/43441/28188373-2f16c6b4-67df-11e7-9b31-d3cf1da0d36d.png)

Tested and confirmed working on LG VK815 tablet running Android 6.0.

Source: http://mobile.developer.lge.com/develop/dev-guides/lg-dual-window-guide/development/enabling-dual-window/