### PR TITLE
Make statusbar transparent

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -185,7 +185,17 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
     void updateBackgroundColor() {
         TerminalSession session = getCurrentTermSession();
         if (session != null && session.getEmulator() != null) {
-            getWindow().getDecorView().setBackgroundColor(session.getEmulator().mColors.mCurrentColors[TextStyle.COLOR_INDEX_BACKGROUND]);
+            View decorView = getWindow().getDecorView();
+            int systemUiVisibility = decorView.getSystemUiVisibility();
+            decorView.setBackgroundColor(session.getEmulator().mColors.mCurrentColors[TextStyle.COLOR_INDEX_BACKGROUND]);
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                if (TerminalColors.COLOR_SCHEME.mLightTheme) {
+                    decorView.setSystemUiVisibility(systemUiVisibility | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                } else {
+                    decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR & ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                }
+            }
         }
     }
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
+<resources xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- See https://developer.android.com/training/material/theme.html for how to customize the Material theme. -->
     <!-- NOTE: Cannot use "Light." since it hides the terminal scrollbar on the default black background. -->
     <style name="Theme.Termux" parent="@android:style/Theme.Material.Light.NoActionBar">
-        <item name="android:statusBarColor">#000000</item>
+        <item name="android:statusBarColor" tools:targetApi="M">@android:color/transparent</item>
         <item name="android:colorPrimary">#FF000000</item>
         <item name="android:windowBackground">@android:color/black</item>
 

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
@@ -59,6 +59,10 @@ public final class TerminalColorScheme {
         // COLOR_INDEX_DEFAULT_FOREGROUND, COLOR_INDEX_DEFAULT_BACKGROUND and COLOR_INDEX_DEFAULT_CURSOR:
         0xffffffff, 0xff000000, 0xffA9AAA9};
 
+    private static final boolean DEFAULT_IS_LIGHT = false;
+
+    public boolean mLightTheme = false;
+
     public final int[] mDefaultColors = new int[TextStyle.NUM_INDEXED_COLORS];
 
     public TerminalColorScheme() {
@@ -67,6 +71,7 @@ public final class TerminalColorScheme {
 
     private void reset() {
         System.arraycopy(DEFAULT_COLORSCHEME, 0, mDefaultColors, 0, TextStyle.NUM_INDEXED_COLORS);
+        mLightTheme = DEFAULT_IS_LIGHT;
     }
 
     public void updateWith(Properties props) {
@@ -76,27 +81,37 @@ public final class TerminalColorScheme {
             String value = (String) entries.getValue();
             int colorIndex;
 
-            if (key.equals("foreground")) {
-                colorIndex = TextStyle.COLOR_INDEX_FOREGROUND;
-            } else if (key.equals("background")) {
-                colorIndex = TextStyle.COLOR_INDEX_BACKGROUND;
-            } else if (key.equals("cursor")) {
-                colorIndex = TextStyle.COLOR_INDEX_CURSOR;
-            } else if (key.startsWith("color")) {
-                try {
-                    colorIndex = Integer.parseInt(key.substring(5));
-                } catch (NumberFormatException e) {
-                    throw new IllegalArgumentException("Invalid property: '" + key + "'");
+            if (key.equals("variant")) {
+                if (value.equals("dark")) {
+                    mLightTheme = false;
+                } else if (value.equals("light")) {
+                    mLightTheme = true;
+                } else {
+                    throw new IllegalArgumentException("Property '" + key + "' has invalid variant: '" + value + "'");
                 }
             } else {
-                throw new IllegalArgumentException("Invalid property: '" + key + "'");
+                if (key.equals("foreground")) {
+                    colorIndex = TextStyle.COLOR_INDEX_FOREGROUND;
+                } else if (key.equals("background")) {
+                    colorIndex = TextStyle.COLOR_INDEX_BACKGROUND;
+                } else if (key.equals("cursor")) {
+                    colorIndex = TextStyle.COLOR_INDEX_CURSOR;
+                } else if (key.startsWith("color")) {
+                    try {
+                        colorIndex = Integer.parseInt(key.substring(5));
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid property: '" + key + "'");
+                    }
+                } else {
+                    throw new IllegalArgumentException("Invalid property: '" + key + "'");
+                }
+
+                int colorValue = TerminalColors.parse(value);
+                if (colorValue == 0)
+                    throw new IllegalArgumentException("Property '" + key + "' has invalid color: '" + value + "'");
+
+                mDefaultColors[colorIndex] = colorValue;
             }
-
-            int colorValue = TerminalColors.parse(value);
-            if (colorValue == 0)
-                throw new IllegalArgumentException("Property '" + key + "' has invalid color: '" + value + "'");
-
-            mDefaultColors[colorIndex] = colorValue;
         }
     }
 


### PR DESCRIPTION
This PR makes the statusbar transparent so it can blend with the current theme. Some notes:

- It only affects API >= 23, so it can turn the statusbar icons dark for light themes.
- It requires an additional property in all themes. I addressed it in this PR *TODO*.