### PR TITLE
Updating manifest to support resizeableActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,9 @@
             android:name="com.termux.app.TermuxActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="adjustResize|stateAlwaysVisible" >
+            android:windowSoftInputMode="adjustResize|stateAlwaysVisible"
+            android:resizeableActivity="true"
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -44,7 +46,8 @@
             android:exported="false"
             android:theme="@android:style/Theme.Material.Light.DarkActionBar"
             android:parentActivityName=".app.TermuxActivity"
-            android:label="@string/application_name" />
+            android:label="@string/application_name"
+            android:resizeableActivity="true"/>
 
         <activity
             android:name="com.termux.filepicker.TermuxFileReceiverActivity"


### PR DESCRIPTION
Updating manifest to support resizeableActivity for main app and help screen. 

[This is also used by Samsung's DeX mode.](http://developer.samsung.com/samsung-dex/modify-optimizing)
