### PR TITLE
added RECORD_AUDIO permission to manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application
         android:extractNativeLibs="true"


### PR DESCRIPTION
Without RECORD_AUDIO permission it is not possible to execute from termux shell applications, such as baresip VOIP user agent, that use OpenSL ES API for playing and recording audio.