### PR TITLE
set default notification priority to low

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -207,8 +207,8 @@ public final class TermuxService extends Service implements SessionChangedCallba
         builder.setOngoing(true);
 
         // If holding a wake or wifi lock consider the notification of high priority since it's using power,
-        // otherwise use a minimal priority since this is just a background service notification:
-        builder.setPriority((wakeLockHeld) ? Notification.PRIORITY_HIGH : Notification.PRIORITY_MIN);
+        // otherwise use a low priority
+        builder.setPriority((wakeLockHeld) ? Notification.PRIORITY_HIGH : Notification.PRIORITY_LOW);
 
         // No need to show a timestamp:
         builder.setShowWhen(false);


### PR DESCRIPTION
since we're a foreground service, in oreo we already get a higher
priority; see
https://developer.android.com/reference/android/app/NotificationManager.html#IMPORTANCE_MIN