### PR TITLE
Fix notification icon color

### DIFF
--- a/app/src/main/res/drawable/ic_service_notification.xml
+++ b/app/src/main/res/drawable/ic_service_notification.xml
@@ -9,7 +9,7 @@
 
     <!-- Screen border. -->
     <path android:fillColor="#00000000"
-          android:strokeColor="#000"
+          android:strokeColor="#FFF"
           android:strokeWidth="3"
           android:pathData="M7,4
                             l34,0
@@ -23,7 +23,7 @@
           />
 
     <!-- Block cursor. -->
-    <path android:fillColor="#000"
+    <path android:fillColor="#FFF"
           android:pathData="M14,14
                             l5,0
                             l0,10


### PR DESCRIPTION
Icons used in notifications/status bar are monochrome and should use only white color and transparency. It is displayed fine on Android emulators but it's shown in black on Samsung Galaxy S7 running Android 7.0.

![screenshot_20180101-200025](https://user-images.githubusercontent.com/1071643/34470449-3ef2458e-ef31-11e7-9c5f-5a2cbd0226dd.png)

After the change, status bar icon is white and the small icon in notification still uses the black color set via setColor(). Termux doesn't support devices running Android older than 5.0 but using white color in vector drawables would be also necessary to generate proper (white) bitmap icons.