### PR TITLE
Fix for #572: merge ~/storage instead of del

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxInstaller.java
+++ b/app/src/main/java/com/termux/app/TermuxInstaller.java
@@ -228,10 +228,12 @@ final class TermuxInstaller {
                 try {
                     File storageDir = new File(TermuxService.HOME_PATH, "storage");
 
+                    /* commented out to merge/overwrite existing folder
                     if (storageDir.exists() && !storageDir.delete()) {
                         Log.e(LOG_TAG, "Could not delete old $HOME/storage");
                         return;
                     }
+		    */
 
                     if (!storageDir.mkdirs()) {
                         Log.e(LOG_TAG, "Unable to mkdirs() for $HOME/storage");


### PR DESCRIPTION
We could recursively delete, as in the method above, but that would
require a separate try block for a separate logcat message, or a
different method that returns a flag. I prefer merging in case of custom
folders. Another alternative may be to send an exit code or something for
the termux-setup-storage script to detect and echo an error message.