### PR TITLE
Make TerminalRenderer public

### DIFF
--- a/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
@@ -16,7 +16,7 @@ import com.termux.terminal.WcWidth;
  * <p/>
  * Saves font metrics, so needs to be recreated each time the typeface or font size changes.
  */
-final class TerminalRenderer {
+public final class TerminalRenderer {
 
     final int mTextSize;
     final Typeface mTypeface;


### PR DESCRIPTION
I want to use the renderer with a custom canvas without having to render to an Android View which requires a context and all sorts of stuff.

Can't currently do that because the renderer is package-private.

The goal is to be able to render this onto a texture in Unity so that people can easily make stuff with termux in VR.