### PR TITLE
add support of configurable extra keys

### DIFF
--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -24,8 +24,6 @@ public final class ExtraKeysView extends GridLayout {
 
     public ExtraKeysView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        reload();
     }
 
     static void sendKey(View view, String keyName) {
@@ -101,23 +99,23 @@ public final class ExtraKeysView extends GridLayout {
         return result;
     }
 
-    void reload() {
+    void reload(final String[][] buttons) {
         altButton = controlButton = null;
         removeAllViews();
 
-        String[][] buttons = {
-            {"ESC", "CTRL", "ALT", "TAB", "―", "/", "|"}
-        };
-
         final int rows = buttons.length;
-        final int cols = buttons[0].length;
+        int mx = 0;
+        for (int row = 0; row < rows; row++) {
+            if(buttons[row].length > mx) mx = buttons[row].length;
+        }
+        final int cols = mx;
 
         setRowCount(rows);
         setColumnCount(cols);
 
         for (int row = 0; row < rows; row++) {
             for (int col = 0; col < cols; col++) {
-                final String buttonText = buttons[row][col];
+                final String buttonText = (buttons[row][col] == null ? " " : buttons[row][col]);
 
                 Button button;
                 switch (buttonText) {

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -217,6 +217,11 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
 
         final ViewPager viewPager = findViewById(R.id.viewpager);
         if (mSettings.isShowExtraKeys()) viewPager.setVisibility(View.VISIBLE);
+        
+        
+        ViewGroup.LayoutParams layoutParams = viewPager.getLayoutParams();
+        layoutParams.height = layoutParams.height * mSettings.mExtraKeys.length;
+        viewPager.setLayoutParams(layoutParams);
 
         viewPager.setAdapter(new PagerAdapter() {
             @Override
@@ -236,6 +241,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 View layout;
                 if (position == 0) {
                     layout = mExtraKeysView = (ExtraKeysView) inflater.inflate(R.layout.extra_keys_main, collection, false);
+                    mExtraKeysView.reload(mSettings.mExtraKeys);
                 } else {
                     layout = inflater.inflate(R.layout.extra_keys_right, collection, false);
                     final EditText editText = layout.findViewById(R.id.text_input);

--- a/app/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/app/src/main/java/com/termux/app/TermuxPreferences.java
@@ -17,6 +17,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import org.json.JSONArray;
 
 final class TermuxPreferences {
 
@@ -103,6 +104,8 @@ final class TermuxPreferences {
         }
         return null;
     }
+    
+    public String[][] mExtraKeys;
 
     public void reloadFromProperties(Context context) {
         try {
@@ -127,6 +130,16 @@ final class TermuxPreferences {
                 default: // "vibrate".
                     mBellBehaviour = BELL_VIBRATE;
                     break;
+            }
+            
+            JSONArray arr = new JSONArray(props.getProperty("extrakeys", "[[\"ESC\",\"CTRL\",\"ALT\",\"TAB\",\"―\",\"/\",\"|\"]]"));
+            mExtraKeys = new String[arr.length()][];
+            for(int i = 0; i < arr.length(); i++) {
+                JSONArray line = arr.getJSONArray(i);
+                mExtraKeys[i] = new String[line.length()];
+                for(int j = 0; j < line.length(); j++) {
+                    mExtraKeys[i][j] = line.getString(j);
+                }
             }
 
             mBackIsEscape = "escape".equals(props.getProperty("back-key", "back"));


### PR DESCRIPTION
People can change extra keys to meet their needs. For example, add one line in termux.properties:
```
extrakeys = [["ESC","CTRL","ALT","TAB","―","/","|"]]
```
That's the default one of Termux.