### PR TITLE
Replace \n with \r when pasting (Fixes #678)

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -2338,8 +2338,8 @@ public final class TerminalEmulator {
     public void paste(String text) {
         // First: Always remove escape key and C1 control characters [0x80,0x9F]:
         text = text.replaceAll("(\u001B|[\u0080-\u009F])", "");
-        // Second: Replace all newlines (\n) with carriage returns (\r).
-        text = text.replace('\n', '\r');
+        // Second: Replace all newlines (\n) or CRLF (\r\n) with carriage returns (\r).
+        text = text.replaceAll("\r?\n", "\r");
 
         // Then: Implement bracketed paste mode if enabled:
         boolean bracketed = isDecsetInternalBitSet(DECSET_BIT_BRACKETED_PASTE_MODE);

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -2338,6 +2338,9 @@ public final class TerminalEmulator {
     public void paste(String text) {
         // First: Always remove escape key and C1 control characters [0x80,0x9F]:
         text = text.replaceAll("(\u001B|[\u0080-\u009F])", "");
+        // Second: Replace all newlines (\n) with carriage returns (\r).
+        text = text.replace('\n', '\r');
+
         // Then: Implement bracketed paste mode if enabled:
         boolean bracketed = isDecsetInternalBitSet(DECSET_BIT_BRACKETED_PASTE_MODE);
         if (bracketed) mSession.write("\033[200~");


### PR DESCRIPTION
Termux will now properly send `\r` to the terminal instead of `\n` when pasting multiline strings.

This fixes `cat` not repeating back lines and `nano` accidentally justifying text (because `\n` maps to `^J`), as well as other potential issues.

This matches the behavior of other terminals, such as iTerm2 which explicitly does it here:
https://github.com/gnachman/iTerm2/blob/f8a5930/sources/iTermPasteHelper.m#L113