### PR TITLE
Hide the keyboard extension when the keyboard is hidden

### DIFF
--- a/app/src/main/res/layout/drawer_layout.xml
+++ b/app/src/main/res/layout/drawer_layout.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"


### PR DESCRIPTION
This fixes https://github.com/termux/termux-app/issues/556

There is one (small) issue with this: It depends on the resizing of the
App caused by the touchscreen keyboard. Due to that, it always thinks that the
keyboard is hidden when the Android splitscreen is used in portrait mode.