### PR TITLE
Add Google Repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven {
             url "https://maven.google.com"


### PR DESCRIPTION
The Google-Repository is required for compilation because some dependencies were removed from jcenter()

This fixes https://github.com/termux/termux-app/issues/713