### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*       text=auto
+*.bat   eol=crlf
+*.sh    eol=lf


### PR DESCRIPTION
This ensures the correct attributes are used when checking out this repo. For example, *.bat files will use CRLF line endings, and *.sh files will use LF endings, regardless of `core.autocrlf` in your global git config.