### PR TITLE
Add permission WRITE_MEDIA_STORAGE

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_MEDIA_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
 


### PR DESCRIPTION
`WRITE_EXTERNAL_STORAGE` provides write access to emulated SD card ("internal storage"). However for some reason it provides only read access to real SD card. This is what happen before and after `WRITE_EXTERNAL_STORAGE` is granted respectively on my phone:

```
$ id
uid=10312(u0_a312) gid=10312(u0_a312) groups=10312(u0_a312),3003(inet),9997(everybody),20312(u0_a312_cache),50312(all_a312)
$ ls -ld /storage/emulated/0
drwxrwx--x 87 root sdcard_rw 4096 Jul  2 15:17 /storage/emulated/0
$ ls -ld /storage/3436-3531
drwxrwx--x 5 root sdcard_rw 32768 Jan  1  1970 /storage/3436-3531
```

```
$ id
uid=10312(u0_a312) gid=10312(u0_a312) groups=10312(u0_a312),3003(inet),9997(everybody),20312(u0_a312_cache),50312(all_a312)
$ ls -ld /storage/emulated/0
drwxrwx--- 87 root everybody 4096 Jul  2 15:17 /storage/emulated/0
$ ls -ld /storage/3436-3531
drwxr-xr-x 5 root everybody 32768 Jan  1  1970 /storage/3436-3531
```

As you can see, although both storage paths' owner group changes from `sdcard_rw` to `everybody` after the permission is granted, the group permission of that of the real SD card changes from `rwx` to `r-x`.

From the data/etc/platform.xml in current platform/frameworks/base master, I can see that the group `sdcard_rw` (along side with `media_rw`) is provided by an undocumented permission named `WRITE_MEDIA_STORAGE`. Therefore, proposing to add the permission to the manifest.

P.S. Not tested so I have no idea if it actually works as expected. Would be great if someone at liberty to build the app can help test this.