### PR TITLE
close sessions without waiting for user input except the last one

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -388,6 +388,11 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                     if (indexOfSession >= 0)
                         showToast(toToastTitle(finishedSession) + " - exited", true);
                 }
+
+                if (mTermService.getSessions().size() > 1) {
+                    removeFinishedSession(finishedSession);
+                }
+
                 mListViewAdapter.notifyDataSetChanged();
             }
 


### PR DESCRIPTION
An attempt to deal with these issues:

 * https://github.com/termux/termux-app/issues/627
 * https://github.com/termux/termux-app/issues/56

This PR makes sessions be closed automatically without pressing enter. However to close last session user will have to press enter - this allows to start a 'fallback' session so user can fix things if normal session can't be started.