### PR TITLE
Alternative patch to fix fn-up fn-down pgup/pgdown

### DIFF
--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -600,7 +600,7 @@ public final class TerminalView extends View {
         if (controlDownFromEvent) keyMod |= KeyHandler.KEYMOD_CTRL;
         if (event.isAltPressed()) keyMod |= KeyHandler.KEYMOD_ALT;
         if (event.isShiftPressed()) keyMod |= KeyHandler.KEYMOD_SHIFT;
-        if (handleKeyCode(keyCode, keyMod)) {
+        if (!event.isFunctionPressed() && handleKeyCode(keyCode, keyMod)) {
             if (LOG_KEY_EVENTS) Log.i(EmulatorDebug.LOG_TAG, "handleKeyCode() took key event");
             return true;
         }
@@ -619,7 +619,7 @@ public final class TerminalView extends View {
         if (LOG_KEY_EVENTS)
             Log.i(EmulatorDebug.LOG_TAG, "KeyEvent#getUnicodeChar(" + effectiveMetaState + ") returned: " + result);
         if (result == 0) {
-            return true;
+            return false;
         }
 
         int oldCombiningAccent = mCombiningAccent;


### PR DESCRIPTION
- in onKeyDown() ignore keys when the Fn key is pressed
- in onKeyDown() return false when the key is not handled.

The above two changes fix the handling of Fn-key combo's on devices with
a physical keyboard, allowing the android system defined fallbacks from
`/system/usr/keychars/Generic.kcm` to be properly handled.

Fixes #731.

Original diagnosis and fix by Konehaltia.