### PR TITLE
Support setting Termux as home launcher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.HOME" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## Overview

This addresses #206 (along with #482 and #880), but in a more canonical way than I suggested in the comments there.

As for launching applications, we can use `am`

```
am start --user 0 <intent>
```

Personally, I wrap these in aliases in my bashrc and it works quite well:

```
app_launch() {
        am start --user 0 "${1}"  >/dev/null
}

alias settings='app_launch "comm.android.settings/.Settings"'
```

## Thoughts

Obviously, my method above requires manual curation. The most annying part is getting the intent uri for newly installed apps, but in #206 @thewisenerd demonstrates one method of easing that hurdle. 