### PR TITLE
terminal-view: fix keyboard's input type

### DIFF
--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -235,14 +235,12 @@ public final class TerminalView extends View {
 
     @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-        // Using InputType.NULL is the most correct input type and avoids issues with other hacks.
-        //
         // Previous keyboard issues:
         // https://github.com/termux/termux-packages/issues/25
         // https://github.com/termux/termux-app/issues/87.
         // https://github.com/termux/termux-app/issues/126.
         // https://github.com/termux/termux-app/issues/137 (japanese chars and TYPE_NULL).
-        outAttrs.inputType = InputType.TYPE_NULL;
+        outAttrs.inputType = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
 
         // Note that IME_ACTION_NONE cannot be used as that makes it impossible to input newlines using the on-screen
         // keyboard on Android TV (see https://github.com/termux/termux-app/issues/221).


### PR DESCRIPTION
On Samsung Galaxy S7 I often getting invalid keyboard type when switching from other application to Termux. This happens on the latest git version as well as on previous ones.

This screenshot perfectly explains what happens:
![screenshot_20181229-171013_termux](https://user-images.githubusercontent.com/25881154/50539719-946d5c00-0b8d-11e9-9d22-fbebf13af97d.jpg)

***

This problem comes from this code in TerminalView.java:
``` .java
outAttrs.inputType = InputType.TYPE_NULL;
```
\- TYPE_NULL does not reset the input type on some devices (Samsung).

~~It also possible that this can deal with https://github.com/termux/termux-app/issues/627.~~

PS. I saw related issue somewhere, don't know where exactly. Maybe either on Gitter or Google+.