### PR TITLE
Reduce the height of viewpager/ExtraKeysView to previous height

### DIFF
--- a/app/src/main/res/layout/drawer_layout.xml
+++ b/app/src/main/res/layout/drawer_layout.xml
@@ -72,7 +72,7 @@
         android:id="@+id/viewpager"
         android:visibility="gone"
         android:layout_width="match_parent"
-        android:layout_height="75dp"
+        android:layout_height="37.5dp"
         android:background="@android:drawable/screen_background_dark_transparent"
         android:layout_alignParentBottom="true" />
 </RelativeLayout>


### PR DESCRIPTION
Commit f0eeb47 introduced configurable extra keys and thus changed the
height of the viewpager to be multipled by the number of rows of extra
keys. However, the extra keys had two rows at the time, so the initial
height should have been changed to half of what it was now that it is
multiplied. This was not done, so the viewpager was twice the height it
should be after that change.