### PR TITLE
implement application menu

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -367,10 +367,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                         showToast(toToastTitle(finishedSession) + " - exited", true);
                 }
 
-                if (mTermService.getSessions().size() > 1) {
-                    removeFinishedSession(finishedSession);
-                }
-
+                removeFinishedSession(finishedSession);
                 mListViewAdapter.notifyDataSetChanged();
             }
 

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -465,7 +465,33 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 TermuxInstaller.setupIfNeeded(TermuxActivity.this, () -> {
                     if (mTermService == null) return; // Activity might have been destroyed.
                     try {
-                        addNewSession(false, null);
+                        String[] menuEntries = {
+                            getString(R.string.menu_normal_start),
+                            getString(R.string.menu_failsafe_start),
+                            getString(R.string.menu_app_exit)
+                        };
+
+                        AlertDialog.Builder dialog = new AlertDialog.Builder(TermuxActivity.this);
+                        dialog.setCancelable(false);
+                        dialog.setIcon(R.drawable.ic_launcher);
+                        dialog.setTitle(R.string.application_name);
+                        dialog.setItems(menuEntries, (dialog1, which) -> {
+                            switch (which) {
+                                case 0:
+                                    addNewSession(false, null);
+                                    break;
+                                case 1:
+                                    addNewSession(true, null);
+                                    break;
+                                case 2:
+                                    mTermService.stopSelf();
+                                    TermuxActivity.this.finish();
+                                    break;
+                                default:
+                                    break;
+                            }
+                        });
+                        dialog.show();
                     } catch (WindowManager.BadTokenException e) {
                         // Activity finished - ignore.
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,11 @@
 <resources>
    <string name="application_name">Termux</string>
    <string name="shared_user_label">Termux user</string>
+
+   <string name="menu_normal_start">Start</string>
+   <string name="menu_failsafe_start">Open failsafe shell</string>
+   <string name="menu_app_exit">Exit</string>
+
    <string name="new_session">New session</string>
    <string name="new_session_failsafe">Failsafe</string>
    <string name="toggle_soft_keyboard">Keyboard</string>


### PR DESCRIPTION
Application menu will allow easy access to failsafe shell without having to deal with auto-closing sessions. At my opinion this will be a perfect solution for https://github.com/termux/termux-app/issues/988. Some people start programs from widgets and want to automatically close sessions on finish.

* Menu is shown on application's cold start.
* Menu is not shown when session is started via widgets.

Screenshot:

![screenshot_1548430885](https://user-images.githubusercontent.com/25881154/51756171-11c2b880-20c9-11e9-90e7-2e2813781adb.png)