### PR TITLE
Allow the user to disable virtual key emulation.

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/app/src/main/java/com/termux/app/TermuxPreferences.java
@@ -65,6 +65,7 @@ final class TermuxPreferences {
     int mBellBehaviour = BELL_VIBRATE;
 
     boolean mBackIsEscape;
+    boolean mDisableVolumeVirtualKeys;
     boolean mShowExtraKeys;
 
     String[][] mExtraKeys;
@@ -191,6 +192,7 @@ final class TermuxPreferences {
         }
 
         mBackIsEscape = "escape".equals(props.getProperty("back-key", "back"));
+        mDisableVolumeVirtualKeys = "volume".equals(props.getProperty("volume-keys", "virtual"));
 
         shortcuts.clear();
         parseAction("shortcut.create-session", SHORTCUT_ACTION_CREATE_SESSION, props);

--- a/app/src/main/java/com/termux/app/TermuxViewClient.java
+++ b/app/src/main/java/com/termux/app/TermuxViewClient.java
@@ -264,7 +264,9 @@ public final class TermuxViewClient implements TerminalViewClient {
     /** Handle dedicated volume buttons as virtual keys if applicable. */
     private boolean handleVirtualKeys(int keyCode, KeyEvent event, boolean down) {
         InputDevice inputDevice = event.getDevice();
-        if (inputDevice != null && inputDevice.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
+        if (mActivity.mSettings.mDisableVolumeVirtualKeys) {
+            return false;
+        } else if (inputDevice != null && inputDevice.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
             // Do not steal dedicated buttons from a full external keyboard.
             return false;
         } else if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {


### PR DESCRIPTION
Adds the option to disable volume button virtual CTRL and FN emulation. Use volume-keys=volume within termux.properties to enable this behaviour.

This should resolve #119.

Tested on Android 8.0.0.