### PR TITLE
Add option to create sessions with the active session's working directory

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -585,7 +585,15 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 }
             }
             String executablePath = (failSafe ? "/system/bin/sh" : null);
-            TerminalSession newSession = mTermService.createTermSession(executablePath, null, null, failSafe);
+            String workingDirectory = null;
+            if (mSettings.mUseCurrentSessionCwd) {
+                final TerminalSession currentSession = getCurrentTermSession();
+                if (currentSession != null) {
+                    workingDirectory = currentSession.getCwd();
+                }
+            }
+
+            TerminalSession newSession = mTermService.createTermSession(executablePath, null, workingDirectory, failSafe);
             if (sessionName != null) {
                 newSession.mSessionName = sessionName;
             }

--- a/app/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/app/src/main/java/com/termux/app/TermuxPreferences.java
@@ -67,6 +67,8 @@ final class TermuxPreferences {
     boolean mBackIsEscape;
     boolean mShowExtraKeys;
 
+    boolean mUseCurrentSessionCwd;
+
     String[][] mExtraKeys;
 
     final List<KeyboardShortcut> shortcuts = new ArrayList<>();
@@ -191,6 +193,8 @@ final class TermuxPreferences {
         }
 
         mBackIsEscape = "escape".equals(props.getProperty("back-key", "back"));
+
+        mUseCurrentSessionCwd = "current".equals(props.getProperty("session.cwd-on-create", "default"));
 
         shortcuts.clear();
         parseAction("shortcut.create-session", SHORTCUT_ACTION_CREATE_SESSION, props);

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
@@ -172,8 +172,14 @@ public final class TerminalSession extends TerminalOutput {
         if (mShellPid < 1)
             return null;
         try {
-            return new File(String.format("/proc/%s/cwd", mShellPid))
+            final String cwdSymlink = String.format("/proc/%s/cwd/", mShellPid);
+            String outputPath = new File(cwdSymlink)
                 .getCanonicalPath();
+            if (!outputPath.endsWith("/"))
+                outputPath += '/';
+
+            if (!cwdSymlink.equals(outputPath))
+                return outputPath;
         } catch (IOException | SecurityException e) {
             // Ignore.
         }

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
@@ -8,6 +8,7 @@ import android.system.Os;
 import android.system.OsConstants;
 import android.util.Log;
 
+import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -164,6 +165,19 @@ public final class TerminalSession extends TerminalOutput {
     /** The terminal title as set through escape sequences or null if none set. */
     public String getTitle() {
         return (mEmulator == null) ? null : mEmulator.getTitle();
+    }
+
+    /** Returns the shell's working directory or null if it was unavailable. */
+    public String getCwd() {
+        if (mShellPid < 1)
+            return null;
+        try {
+            return new File(String.format("/proc/%s/cwd", mShellPid))
+                .getCanonicalPath();
+        } catch (IOException | SecurityException e) {
+            // Ignore.
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Adds the option to create new Termux sessions with the active shell's working directory.

Use session.cwd-on-create=current within termux.properties to enable this behaviour.
