### PR TITLE
sessions: failsafe session is now accessible via separate launcher icon

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,12 +37,23 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+                <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
             <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts" />
+        </activity>
+
+        <activity
+            android:name="com.termux.app.TermuxFailsafeActivity"
+            android:label="@string/app_failsafe_mode" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/com/termux/app/TermuxFailsafeActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxFailsafeActivity.java
@@ -1,0 +1,19 @@
+package com.termux.app;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+public final class TermuxFailsafeActivity extends Activity {
+
+    public static final String TERMUX_FAILSAFE_SESSION_ACTION = "com.termux.app.failsafe_session";
+
+    @Override
+    public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        Intent intent = new Intent(TermuxFailsafeActivity.this, TermuxActivity.class);
+        intent.putExtra(TERMUX_FAILSAFE_SESSION_ACTION, true);
+        startActivity(intent);
+        finish();
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
    <string name="application_name">Termux</string>
    <string name="shared_user_label">Termux user</string>
+   <string name="app_failsafe_mode">Termux (failsafe)</string>
    <string name="new_session">New session</string>
    <string name="new_session_failsafe">Failsafe</string>
    <string name="toggle_soft_keyboard">Keyboard</string>


### PR DESCRIPTION
Enables additional launcher icon that causes to be a failsafe session to be started instead of default.
This PR also makes session auto-closeable on exit coded *0* and *130*. Any other exit codes should be handled by user on it's own in order to avoid messages about "Press enter".

Old "failsafe" session button left untouched since it may be useful in some cases to start system shell instead of Termux's one.