### PR TITLE
Tweak notification icon color to make it work with dark notifcations

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -214,7 +214,7 @@ public final class TermuxService extends Service implements SessionChangedCallba
         builder.setShowWhen(false);
 
         // Background color for small notification icon:
-        builder.setColor(0xFF000000);
+        builder.setColor(0xFF607D8B);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             builder.setChannelId(NOTIFICATION_CHANNEL_ID);


### PR DESCRIPTION
As the notification icon and text is set to black, ROMs like Samsung OneUI and themes that change notifications to have a dark background will have visibility issues with Termux notifications. This commit sets a neutral color which will be visible on both white and dark backgrounds.