### PR TITLE
Change method name 'with' to 'getInstance'

### DIFF
--- a/app/src/main/java/com/termux/app/BellUtil.java
+++ b/app/src/main/java/com/termux/app/BellUtil.java
@@ -10,7 +10,7 @@ public class BellUtil {
     private static BellUtil instance = null;
     private static final Object lock = new Object();
 
-    public static BellUtil with(Context context) {
+    public static BellUtil getInstance(Context context) {
         if (instance == null) {
             synchronized (lock) {
                 if (instance == null) {

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -24,7 +24,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.os.Vibrator;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
@@ -402,7 +401,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                         mBellSoundPool.play(mBellSoundId, 1.f, 1.f, 1, 0, 1.f);
                         break;
                     case TermuxPreferences.BELL_VIBRATE:
-                        BellUtil.with(TermuxActivity.this).doBell();
+                        BellUtil.getInstance(TermuxActivity.this).doBell();
                         break;
                     case TermuxPreferences.BELL_IGNORE:
                         // Ignore the bell character.


### PR DESCRIPTION
This class is used to represent BellUtil.  This method named 'with' is to return the singleton of BellUtil instance. Thus, the method name 'getInstance' is more intuitive than 'with'.