### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,7 +110,7 @@
 
         <service
             android:name="com.termux.app.TermuxService"
-            android:exported="false" />
+            android:exported="true" />
 
         <receiver android:name=".app.TermuxOpenReceiver" />
 


### PR DESCRIPTION
Set `exported="true"`, so other apps can start termux service.