### PR TITLE
Ignore battery optimization settings to prevent suspension

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 
     <application
         android:extractNativeLibs="true"

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -16,6 +16,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.PowerManager;
+import android.provider.Settings;
 import android.util.Log;
 import android.widget.ArrayAdapter;
 
@@ -111,6 +112,17 @@ public final class TermuxService extends Service implements SessionChangedCallba
                 WifiManager wm = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
                 mWifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, EmulatorDebug.LOG_TAG);
                 mWifiLock.acquire();
+
+                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    String packageName = getPackageName();
+                    if (!pm.isIgnoringBatteryOptimizations(packageName)) {
+                        Intent whitelist = new Intent();
+                        whitelist.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+                        whitelist.setData(Uri.parse("package:" + packageName));
+                        whitelist.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        startActivity(whitelist);
+                    }
+                }
 
                 updateNotification();
             }


### PR DESCRIPTION
Fixes #377 by whitelisting termux when the user clicks on the wakelock button for the first time.

Even if the [android docs](https://developer.android.com/training/monitoring-device-state/doze-standby.html) say a foreground service is enough to prevent suspension, on my devices running CLI services stop sending UDP/TCP packets and get suspended if the app is reduced or the device is locked.
This is especially noticeable when running a simple `time ping 192.168.1.1`; on resume, the ICMP sequence number is way lower than the number of elapsed seconds, indicating a suspension of the process.

Anyway, I encountered this issue on my devices and noticed that manual whitelisting fixed it, thought I could contribute with an automated fix.