### PR TITLE
Disable backups by Google services

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,8 +18,7 @@
 
     <application
         android:extractNativeLibs="true"
-        android:allowBackup="true"
-        android:fullBackupContent="@xml/backupscheme"
+        android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
         android:banner="@drawable/banner"
         android:label="@string/application_name"

--- a/app/src/main/res/xml/backupscheme.xml
+++ b/app/src/main/res/xml/backupscheme.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<full-backup-content>
-    <!-- See https://developer.android.com/training/backup/autosyncapi.html -->
-    <include domain="file" path="home/backup" />
-</full-backup-content>


### PR DESCRIPTION
Why:
* During backup process Termux is being killed in most cases.
* Backup data is limited to 25 MB.
* Backup may not be performed/updated in certain cases.

One of the reasons why issue https://github.com/termux/termux-app/issues/122 happens.