### PR TITLE
extra keys: handle actions UP & CANCEL separately

### DIFF
--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -354,9 +354,13 @@ public final class ExtraKeysView extends GridLayout {
                     if (Settings.System.getInt(getContext().getContentResolver(),
                         Settings.System.HAPTIC_FEEDBACK_ENABLED, 0) != 0) {
 
-                        // Depending on DnD settings, value can be >1 but 0 means "disabled".
-                        if (Settings.Global.getInt(getContext().getContentResolver(), "zen_mode", 0) < 1) {
+                        if (Build.VERSION.SDK_INT >= 28) {
                             finalButton.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
+                        } else {
+                            // Perform haptic feedback only if no total silence mode enabled.
+                            if (Settings.Global.getInt(getContext().getContentResolver(), "zen_mode", 0) != 2) {
+                                finalButton.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -401,8 +401,14 @@ public final class ExtraKeysView extends GridLayout {
                             }
                             return true;
 
-                        case MotionEvent.ACTION_UP:
                         case MotionEvent.ACTION_CANCEL:
+                            v.setBackgroundColor(BUTTON_COLOR);
+                            if (scheduledExecutor != null) {
+                                scheduledExecutor.shutdownNow();
+                                scheduledExecutor = null;
+                            }
+                            return true;
+                        case MotionEvent.ACTION_UP:
                             v.setBackgroundColor(BUTTON_COLOR);
                             if (scheduledExecutor != null) {
                                 scheduledExecutor.shutdownNow();


### PR DESCRIPTION
Extra keys shouldn't perform any action if button click was cancelled.
Fixes: https://github.com/termux/termux-app/issues/905.

Additionally:

* Disable manual handling of DnD for API 28 and higher (Google simplified it and seems there no way to detect total silence mode). Maybe for higher SDK versions we even do not need to handle it manually, but I don't have device to verify this.