### PR TITLE
BackgroundJob command result responses

### DIFF
--- a/app/src/main/java/com/termux/app/BackgroundJob.java
+++ b/app/src/main/java/com/termux/app/BackgroundJob.java
@@ -90,7 +90,7 @@ public final class BackgroundJob {
                     // Ignore.
                 }
             }
-        };
+        }.start();
     }
 
     private static void addToEnvIfPresent(List<String> environment, String name) {

--- a/app/src/main/java/com/termux/app/BackgroundJob.java
+++ b/app/src/main/java/com/termux/app/BackgroundJob.java
@@ -1,5 +1,9 @@
 package com.termux.app;
 
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.os.Bundle;
 import android.util.Log;
 
 import java.io.BufferedReader;
@@ -24,7 +28,11 @@ public final class BackgroundJob {
 
     final Process mProcess;
 
-    public BackgroundJob(String cwd, String fileToExecute, final String[] args, final TermuxService service) {
+    public BackgroundJob(String cwd, String fileToExecute, final String[] args, final TermuxService service){
+        this(cwd, fileToExecute, args, service, null);
+    }
+
+    public BackgroundJob(String cwd, String fileToExecute, final String[] args, final TermuxService service, PendingIntent pendingIntent) {
         String[] env = buildEnvironment(false, cwd);
         if (cwd == null) cwd = TermuxService.HOME_PATH;
 
@@ -43,6 +51,28 @@ public final class BackgroundJob {
 
         mProcess = process;
         final int pid = getPid(mProcess);
+        final Bundle result = new Bundle();
+        final StringBuilder outResult = new StringBuilder();
+        final StringBuilder errResult = new StringBuilder();
+
+        Thread errThread = new Thread() {
+            @Override
+            public void run() {
+                InputStream stderr = mProcess.getErrorStream();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(stderr, StandardCharsets.UTF_8));
+                String line;
+                try {
+                    // FIXME: Long lines.
+                    while ((line = reader.readLine()) != null) {
+                        errResult.append(line).append('\n');
+                        Log.i(LOG_TAG, "[" + pid + "] stderr: " + line);
+                    }
+                } catch (IOException e) {
+                    // Ignore.
+                }
+            }
+        };
+        errThread.start();
 
         new Thread() {
             @Override
@@ -50,11 +80,13 @@ public final class BackgroundJob {
                 Log.i(LOG_TAG, "[" + pid + "] starting: " + processDescription);
                 InputStream stdout = mProcess.getInputStream();
                 BufferedReader reader = new BufferedReader(new InputStreamReader(stdout, StandardCharsets.UTF_8));
+
                 String line;
                 try {
                     // FIXME: Long lines.
                     while ((line = reader.readLine()) != null) {
                         Log.i(LOG_TAG, "[" + pid + "] stdout: " + line);
+                        outResult.append(line).append('\n');
                     }
                 } catch (IOException e) {
                     Log.e(LOG_TAG, "Error reading output", e);
@@ -68,26 +100,25 @@ public final class BackgroundJob {
                     } else {
                         Log.w(LOG_TAG, "[" + pid + "] exited with code: " + exitCode);
                     }
-                } catch (InterruptedException e) {
-                    // Ignore.
-                }
-            }
-        }.start();
 
+                    result.putString("stdout", outResult.toString());
+                    result.putInt("exitCode", exitCode);
 
-        new Thread() {
-            @Override
-            public void run() {
-                InputStream stderr = mProcess.getErrorStream();
-                BufferedReader reader = new BufferedReader(new InputStreamReader(stderr, StandardCharsets.UTF_8));
-                String line;
-                try {
-                    // FIXME: Long lines.
-                    while ((line = reader.readLine()) != null) {
-                        Log.i(LOG_TAG, "[" + pid + "] stderr: " + line);
+                    errThread.join();
+                    result.putString("stderr", errResult.toString());
+
+                    Intent data = new Intent();
+                    data.putExtra("result", result);
+
+                    if(pendingIntent != null) {
+                        try {
+                            pendingIntent.send(service.getApplicationContext(), Activity.RESULT_OK, data);
+                        } catch (PendingIntent.CanceledException e) {
+                            // The caller doesn't want the result? That's fine, just ignore
+                        }
                     }
-                } catch (IOException e) {
-                    // Ignore.
+                } catch (InterruptedException e) {
+                    // Ignore
                 }
             }
         }.start();

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -148,7 +148,7 @@ public final class TermuxService extends Service implements SessionChangedCallba
             String cwd = intent.getStringExtra(EXTRA_CURRENT_WORKING_DIRECTORY);
 
             if (intent.getBooleanExtra(EXTRA_EXECUTE_IN_BACKGROUND, false)) {
-                BackgroundJob task = new BackgroundJob(cwd, executablePath, arguments, this);
+                BackgroundJob task = new BackgroundJob(cwd, executablePath, arguments, this, intent.getParcelableExtra("pendingIntent"));
                 mBackgroundTasks.add(task);
                 updateNotification();
             } else {


### PR DESCRIPTION
I've added an optional final argument to the BackgroundJob constructor for a `PendingIntent` that it will respond to with the results of the commands that it has run. (A "result" bundle containing stdout, stderr, and the process exit status)

I've also added a `"pendingIntent"` extra that will be pulled from `service_execute` requests that can hold these new PendingIntents, so Termux can respond to things that can invoke these intents with the resulting command's output.

The immediate practicality of this is that it will allow things like [this issue in termux-tasker](https://github.com/termux/termux-tasker/issues/21) to be solved.