### PR TITLE
ExtraKeysView: Ability to modify ExtraKeysView colours

### DIFF
--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -10,7 +10,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ScheduledExecutorService;
 
 import java.util.Map;
-import java.util.HashMap;
+import java.util.HashMap; 
+import java.io.File;
 import java.util.Arrays;
 
 import android.view.HapticFeedbackConstants;

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -57,6 +57,7 @@ public final class ExtraKeysView extends GridLayout {
 		int color = Color.WHITE;
 		String[] keys = new String [] {"extra-key-color", "extra-key-checked-color", "extra-key-pressed-color"};
 		for ( String key : keys) {
+          caught = false;
 			try	{
 				String path = "/data/data/com.termux/files/home/.termux/termux.properties";
 				File file = new File(path);

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -57,7 +57,7 @@ public final class ExtraKeysView extends GridLayout {
 		int color = Color.WHITE;
 		String[] keys = new String [] {"extra-key-color", "extra-key-checked-color", "extra-key-pressed-color"};
 		for ( String key : keys) {
-            caught = false;
+                caught = false;
 			try	{
 				String path = "/data/data/com.termux/files/home/.termux/termux.properties";
 				File file = new File(path);

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -12,7 +12,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.Map;
 import java.util.HashMap; 
 import java.io.File;
-import java.util.Arrays;
+import java.util.Arrays; 
+import java.util.Properties; 
+import java.util.io.InputStream;
+import java.util.io.FileInputStream;
 
 import android.view.HapticFeedbackConstants;
 import android.view.KeyEvent;

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -14,13 +14,14 @@ import java.util.HashMap;
 import java.io.File;
 import java.util.Arrays; 
 import java.util.Properties; 
-import java.util.io.InputStream;
-import java.util.io.FileInputStream;
+import java.io.InputStream;
+import java.io.FileInputStream;
 
 import android.view.HapticFeedbackConstants;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
-import android.view.View;
+import android.view.View; 
+import android.graphics.Color;
 import android.widget.Button;
 import android.widget.GridLayout;
 import android.widget.PopupWindow;

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -57,7 +57,7 @@ public final class ExtraKeysView extends GridLayout {
 		int color = Color.WHITE;
 		String[] keys = new String [] {"extra-key-color", "extra-key-checked-color", "extra-key-pressed-color"};
 		for ( String key : keys) {
-          caught = false;
+            caught = false;
 			try	{
 				String path = "/data/data/com.termux/files/home/.termux/termux.properties";
 				File file = new File(path);
@@ -73,7 +73,7 @@ public final class ExtraKeysView extends GridLayout {
 				int position = Arrays.asList(keys).indexOf(key);
 				switch(position) {
 					case 0:
-						TEXT_COLOR = caught ? 0xFFFFFF : color;
+						TEXT_COLOR = color;
 						break;
 					case 1:
 						INTERESTING_COLOR = caught ? 0xFF80DEEA : color;

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -32,15 +32,52 @@ import com.termux.view.TerminalView;
  */
 public final class ExtraKeysView extends GridLayout {
 
-    private static final int TEXT_COLOR = 0xFFFFFFFF;
+    private static int TEXT_COLOR;
     private static final int BUTTON_COLOR = 0x00000000;
-    private static final int INTERESTING_COLOR = 0xFF80DEEA;
-    private static final int BUTTON_PRESSED_COLOR = 0x7FFFFFFF;
+    private static int INTERESTING_COLOR;
+    private static int BUTTON_PRESSED_COLOR;
 
     public ExtraKeysView(Context context, AttributeSet attrs) {
-        super(context, attrs);
+        super(context, attrs); 
+        setButtonColor();
     }
-    
+    /* 
+     * Get color values set by user in termux.properties.
+     * Set TEXT_COLOR, INTERESTING_COLOR, and BUTTON_PRESSED_COLOR based on user values,
+     * or fallback values, if not present.
+     */
+    public void setButtonColor() {
+		InputStream fileInputStream;
+		boolean caught = false;
+		int color = Color.WHITE;
+		String[] keys = new String [] {"extra-key-color", "extra-key-checked-color", "extra-key-pressed-color"};
+		for ( String key : keys) {
+			try	{
+				String path = "/data/data/com.termux/files/home/.termux/termux.properties";
+				File file = new File(path);
+				Properties properties = new Properties();
+				fileInputStream = new FileInputStream(file);
+				properties.load(fileInputStream);
+				fileInputStream.close();
+				color = Color.parseColor(properties.getProperty(key));
+				}
+				catch (Throwable th) {
+					caught = true;
+				}
+				int position = Arrays.asList(keys).indexOf(key);
+				switch(position) {
+					case 0:
+						TEXT_COLOR = caught ? 0xFFFFFF : color;
+						break;
+					case 1:
+						INTERESTING_COLOR = caught ? 0xFF80DEEA : color;
+						break;
+					case 2:
+						BUTTON_PRESSED_COLOR = caught ? 0x7FFFFFFF : color;
+						break;
+				}
+	    }		
+	}
     /**
      * HashMap that implements Python dict.get(key, default) function.
      * Default java.util .get(key) is then the same as .get(key, null);


### PR DESCRIPTION
In this commit, I propose the ability to allow the user to modify the colours of ExtraKeysView in `termux.properties`, using the following keys: `extra-key-color`, `extra-key-checked-color`, and `extra-key-pressed-color`.

Note: Due to not having access to a working PC at the moment, a watered down version of this was tested via a bunch of edits to the smali code, and has not been tested as-is.