### PR TITLE
Set orientation of HandleView in show

### DIFF
--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -973,7 +973,7 @@ public final class TerminalView extends View {
             return mContainer.isShowing();
         }
 
-        private void checkChangedOrientation() {
+        private void checkChangedOrientation(int posX) {
             if (!mIsDragging) {
                 return;
             }
@@ -1003,10 +1003,7 @@ public final class TerminalView extends View {
                 return;
             }
 
-            final int[] coords = mTempCoords;
-            hostView.getLocationInWindow(coords);
-            final int posX = coords[0] + mPointX;
-            if (posX < clip.left) {
+            if (posX - mHandleWidth < clip.left) {
                 changeOrientation(RIGHT);
             } else if (posX + mHandleWidth > clip.right) {
                 changeOrientation(LEFT);
@@ -1051,9 +1048,9 @@ public final class TerminalView extends View {
         }
 
         private void moveTo(int x, int y) {
-            mPointX = x;
+            mPointX = (int) (x - mHotspotX);
             mPointY = y;
-            checkChangedOrientation();
+            checkChangedOrientation(x);
             if (isPositionVisible()) {
                 int[] coords = null;
                 if (mContainer.isShowing()) {
@@ -1139,7 +1136,7 @@ public final class TerminalView extends View {
         }
 
         void positionAtCursor(final int cx, final int cy) {
-            int left = (int) (getPointX(cx) - mHotspotX);
+            int left = getPointX(cx);
             int bottom = getPointY(cy + 1);
             moveTo(left, bottom);
         }

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -1240,7 +1240,7 @@ public final class TerminalView extends View {
                 public void onGetContentRect(ActionMode mode, View view, Rect outRect) {
                     int x1 = Math.round(mSelX1 * mRenderer.mFontWidth);
                     int x2 = Math.round(mSelX2 * mRenderer.mFontWidth);
-                    int y1 = Math.round((mSelY1 - mTopRow) * mRenderer.mFontLineSpacing);
+                    int y1 = Math.round((mSelY1 - 1 - mTopRow) * mRenderer.mFontLineSpacing);
                     int y2 = Math.round((mSelY2 + 1 - mTopRow) * mRenderer.mFontLineSpacing);
 
 


### PR DESCRIPTION
When you hold down on a word that starts or ends at the edge of the
screen, the handle will appear outside of the screen. This happens
because the orientation was only switched when the handle is dragged, so
when it is shown it just used the same orientation as it had for the
last selection.

Relates to #334, but not sure if it fixes it completely.

Before:
![image](https://user-images.githubusercontent.com/601966/75606906-fdce5f00-5af1-11ea-93f0-94ec3633b5bc.png)

After:
![image](https://user-images.githubusercontent.com/601966/75606908-02931300-5af2-11ea-873f-0cef42ee9357.png)

This is when holding down on the word "Working".