### PR TITLE
Improvements to extra keys

### DIFF
--- a/app/src/main/java/com/termux/app/ExtraKeysInfos.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysInfos.java
@@ -115,6 +115,7 @@ public class ExtraKeysInfos {
         put("TAB", "↹"); // U+21B9 ↹ LEFTWARDS ARROW TO BAR OVER RIGHTWARDS ARROW TO BAR
         put("BKSP", "⌫"); // U+232B ⌫ ERASE TO THE LEFT sometimes seen and easy to understand
         put("DEL", "⌦"); // U+2326 ⌦ ERASE TO THE RIGHT not well known but easy to understand
+        put("DRAWER", "☰"); // U+2630 ☰ TRIGRAM FOR HEAVEN not well known but easy to understand
         put("KEYBOARD", "⌨"); // U+2328 ⌨ KEYBOARD not well known but easy to understand
     }};
 

--- a/app/src/main/java/com/termux/app/ExtraKeysInfos.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysInfos.java
@@ -21,14 +21,8 @@ public class ExtraKeysInfos {
      */
     private String style = "default";
 
-    /**
-     * This is the keyMap defined in termux.properties
-     */
-    private Map<String, String> keyMap;
-
-    public ExtraKeysInfos(String propertiesInfo, Map<String, String> keyMap, String style) throws JSONException {
+    public ExtraKeysInfos(String propertiesInfo, String style) throws JSONException {
         this.style = style;
-        this.keyMap = keyMap;
 
         // Convert String propertiesInfo to Array of Arrays
         JSONArray arr = new JSONArray(propertiesInfo);
@@ -84,10 +78,6 @@ public class ExtraKeysInfos {
 
     public ExtraKeyButton[][] getMatrix() {
         return buttons;
-    }
-
-    public Map<String, String> getKeyMap() {
-        return keyMap;
     }
 
     /**
@@ -336,9 +326,5 @@ class ExtraKeyButton {
             return this.displayedTextFromConfig;
         else
             return parent.getSelectedCharMap().get(key, key);
-    }
-
-    public ExtraKeysInfos getParent() {
-        return parent;
     }
 }

--- a/app/src/main/java/com/termux/app/ExtraKeysInfos.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysInfos.java
@@ -6,8 +6,10 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ExtraKeysInfos {
 
@@ -285,23 +287,32 @@ class ExtraKeyButton {
     public ExtraKeyButton(ExtraKeysInfos.CharDisplayMap charDisplayMap, JSONObject config, ExtraKeyButton popup) throws JSONException {
         String keyFromConfig = config.optString("key", null);
         String macroFromConfig = config.optString("macro", null);
+        String[] keys;
         if (keyFromConfig != null && macroFromConfig != null) {
             throw new JSONException("Both key and macro can't be set for the same key");
         } else if (keyFromConfig != null) {
-            this.key = ExtraKeysInfos.replaceAlias(keyFromConfig);
+            keys = new String[]{keyFromConfig};
             this.macro = false;
         } else if (macroFromConfig != null) {
-            this.key = macroFromConfig;
+            keys = macroFromConfig.split(" ");
             this.macro = true;
         } else {
             throw new JSONException("All keys have to specify either key or macro");
         }
 
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = ExtraKeysInfos.replaceAlias(keys[i]);
+        }
+
+        this.key = String.join(" ", keys);
+
         String displayFromConfig = config.optString("display", null);
         if (displayFromConfig != null) {
             this.display = displayFromConfig;
         } else {
-            this.display = charDisplayMap.get(this.key, this.key);
+            this.display = Arrays.stream(keys)
+                .map(key -> charDisplayMap.get(key, key))
+                .collect(Collectors.joining(" "));
         }
 
         this.popup = popup;

--- a/app/src/main/java/com/termux/app/ExtraKeysInfos.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysInfos.java
@@ -1,0 +1,190 @@
+package com.termux.app;
+
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExtraKeysInfos {
+
+    /**
+     * Matrix of buttons displayed
+     */
+    private String [][][] buttons;
+
+    /**
+     * This corresponds to one of the CharMapDisplay below
+     */
+    private String style = "default";
+
+    /**
+     * This is the keyMap defined in termux.properties
+     */
+    private Map<String, String> keyMap;
+
+    public ExtraKeysInfos(String[][][] buttons, Map<String, String> keyMap, String style) {
+        this.style = style;
+        this.keyMap = keyMap;
+        this.buttons = buttons;
+    }
+
+    /**
+     * HashMap that implements Python dict.get(key, default) function.
+     * Default java.util .get(key) is then the same as .get(key, null);
+     */
+    static class CleverMap<K,V> extends HashMap<K,V> {
+        V get(K key, V defaultValue) {
+            if(containsKey(key))
+                return get(key);
+            else
+                return defaultValue;
+        }
+    }
+
+    static class CharDisplayMap extends CleverMap<String, String> {}
+
+    /**
+     * Keys are displayed in a natural looking way, like "→" for "RIGHT"
+     */
+    static final CharDisplayMap classicArrowsDisplay = new CharDisplayMap() {{
+        // classic arrow keys (for ◀ ▶ ▲ ▼ @see arrowVariationDisplay)
+        put("LEFT", "←"); // U+2190 ← LEFTWARDS ARROW
+        put("RIGHT", "→"); // U+2192 → RIGHTWARDS ARROW
+        put("UP", "↑"); // U+2191 ↑ UPWARDS ARROW
+        put("DOWN", "↓"); // U+2193 ↓ DOWNWARDS ARROW
+    }};
+
+    static final CharDisplayMap wellKnownCharactersDisplay = new CharDisplayMap() {{
+        // well known characters // https://en.wikipedia.org/wiki/{Enter_key, Tab_key, Delete_key}
+        put("ENTER", "↲"); // U+21B2 ↲ DOWNWARDS ARROW WITH TIP LEFTWARDS
+        put("TAB", "↹"); // U+21B9 ↹ LEFTWARDS ARROW TO BAR OVER RIGHTWARDS ARROW TO BAR
+        put("BKSP", "⌫"); // U+232B ⌫ ERASE TO THE LEFT sometimes seen and easy to understand
+        put("DEL", "⌦"); // U+2326 ⌦ ERASE TO THE RIGHT not well known but easy to understand
+        put("KEYBOARD", "⌨"); // U+2328 ⌨ KEYBOARD not well known but easy to understand
+    }};
+
+    static final CharDisplayMap lessKnownCharactersDisplay = new CharDisplayMap() {{
+        // https://en.wikipedia.org/wiki/{Home_key, End_key, Page_Up_and_Page_Down_keys}
+        // home key can mean "goto the beginning of line" or "goto first page" depending on context, hence the diagonal
+        put("HOME", "⇱"); // from IEC 9995 // U+21F1 ⇱ NORTH WEST ARROW TO CORNER
+        put("END", "⇲"); // from IEC 9995 // ⇲ // U+21F2 ⇲ SOUTH EAST ARROW TO CORNER
+        put("PGUP", "⇑"); // no ISO character exists, U+21D1 ⇑ UPWARDS DOUBLE ARROW will do the trick
+        put("PGDN", "⇓"); // no ISO character exists, U+21D3 ⇓ DOWNWARDS DOUBLE ARROW will do the trick
+    }};
+
+    static final CharDisplayMap arrowTriangleVariationDisplay = new CharDisplayMap() {{
+        // alternative to classic arrow keys
+        put("LEFT", "◀"); // U+25C0 ◀ BLACK LEFT-POINTING TRIANGLE
+        put("RIGHT", "▶"); // U+25B6 ▶ BLACK RIGHT-POINTING TRIANGLE
+        put("UP", "▲"); // U+25B2 ▲ BLACK UP-POINTING TRIANGLE
+        put("DOWN", "▼"); // U+25BC ▼ BLACK DOWN-POINTING TRIANGLE
+    }};
+
+    static final CharDisplayMap notKnownIsoCharacters = new CharDisplayMap() {{
+        // Control chars that are more clear as text // https://en.wikipedia.org/wiki/{Function_key, Alt_key, Control_key, Esc_key}
+        // put("FN", "FN"); // no ISO character exists
+        put("CTRL", "⎈"); // ISO character "U+2388 ⎈ HELM SYMBOL" is unknown to people and never printed on computers, however "U+25C7 ◇ WHITE DIAMOND" is a nice presentation, and "^" for terminal app and mac is often used
+        put("ALT", "⎇"); // ISO character "U+2387 ⎇ ALTERNATIVE KEY SYMBOL'" is unknown to people and only printed as the Option key "⌥" on Mac computer
+        put("ESC", "⎋"); // ISO character "U+238B ⎋ BROKEN CIRCLE WITH NORTHWEST ARROW" is unknown to people and not often printed on computers
+    }};
+
+    static final CharDisplayMap nicerLookingDisplay = new CharDisplayMap() {{
+        // nicer looking for most cases
+        put("-", "―"); // U+2015 ― HORIZONTAL BAR
+    }};
+
+    /**
+     * Keys are displayed in a natural looking way, like "→" for "RIGHT" or "↲" for ENTER
+     */
+    public static final CharDisplayMap defaultCharDisplay = new CharDisplayMap() {{
+        putAll(classicArrowsDisplay);
+        putAll(wellKnownCharactersDisplay);
+        putAll(nicerLookingDisplay);
+        // all other characters are displayed as themselves
+    }};
+
+    public static final CharDisplayMap lotsOfArrowsCharDisplay = new CharDisplayMap() {{
+        putAll(classicArrowsDisplay);
+        putAll(wellKnownCharactersDisplay);
+        putAll(lessKnownCharactersDisplay); // NEW
+        putAll(nicerLookingDisplay);
+    }};
+
+    public static final CharDisplayMap arrowsOnlyCharDisplay = new CharDisplayMap() {{
+        putAll(classicArrowsDisplay);
+        // putAll(wellKnownCharactersDisplay); // REMOVED
+        // putAll(lessKnownCharactersDisplay); // REMOVED
+        putAll(nicerLookingDisplay);
+    }};
+
+    public static final CharDisplayMap fullIsoCharDisplay = new CharDisplayMap() {{
+        putAll(classicArrowsDisplay);
+        putAll(wellKnownCharactersDisplay);
+        putAll(lessKnownCharactersDisplay); // NEW
+        putAll(nicerLookingDisplay);
+        putAll(notKnownIsoCharacters); // NEW
+    }};
+
+    /**
+     * Some people might call our keys differently
+     */
+    static final CharDisplayMap controlCharsAliases = new CharDisplayMap() {{
+        put("ESCAPE", "ESC");
+        put("CONTROL", "CTRL");
+        put("RETURN", "ENTER"); // Technically different keys, but most applications won't see the difference
+        put("FUNCTION", "FN");
+        // no alias for ALT
+
+        // Directions are sometimes written as first and last letter for brevety
+        put("LT", "LEFT");
+        put("RT", "RIGHT");
+        put("DN", "DOWN");
+        // put("UP", "UP"); well, "UP" is already two letters
+
+        put("PAGEUP", "PGUP");
+        put("PAGE_UP", "PGUP");
+        put("PAGE UP", "PGUP");
+        put("PAGE-UP", "PGUP");
+
+        // no alias for HOME
+        // no alias for END
+
+        put("PAGEDOWN", "PGDN");
+        put("PAGE_DOWN", "PGDN");
+        put("PAGE-DOWN", "PGDN");
+
+        put("DELETE", "DEL");
+        put("BACKSPACE", "BKSP");
+
+        // easier for writing in termux.properties
+        put("BACKSLASH", "\\");
+        put("QUOTE", "\"");
+        put("APOSTROPHE", "'");
+    }};
+
+    CharDisplayMap getSelectedCharMap() {
+        switch (style) {
+            case "arrows-only":
+                return arrowsOnlyCharDisplay;
+            case "arrows-all":
+                return lotsOfArrowsCharDisplay;
+            case "all":
+                return fullIsoCharDisplay;
+            case "none":
+                return new CharDisplayMap();
+            default:
+                return defaultCharDisplay;
+        }
+    }
+
+    /**
+     * Applies the 'controlCharsAliases' mapping to all the strings in *buttons*
+     * Modifies the array, doesn't return a new one.
+     */
+    public static void replaceAliases(String[][][] buttons) {
+        for(int i = 0; i < buttons.length; i++)
+            for(int j = 0; j < buttons[i].length; j++)
+                for(int k = 0; k < buttons[i][j].length; k++)
+                    buttons[i][j][k] = controlCharsAliases.get(buttons[i][j][k], buttons[i][j][k]);
+    }
+}

--- a/app/src/main/java/com/termux/app/ExtraKeysInfos.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysInfos.java
@@ -48,11 +48,12 @@ public class ExtraKeysInfos {
 
                 if(! jobject.has("popup")) {
                     // no popup
-                    button = new ExtraKeyButton(this, jobject);
+                    button = new ExtraKeyButton(getSelectedCharMap(), jobject);
                 } else {
                     // a popup
                     JSONObject popupJobject = normalizeKeyConfig(jobject.get("popup"));
-                    button = new ExtraKeyButton(this, jobject, new ExtraKeyButton(this, popupJobject));
+                    ExtraKeyButton popup = new ExtraKeyButton(getSelectedCharMap(), popupJobject);
+                    button = new ExtraKeyButton(getSelectedCharMap(), jobject, popup);
                 }
 
                 this.buttons[i][j] = button;
@@ -267,28 +268,21 @@ class ExtraKeyButton {
     private boolean macro;
 
     /**
+     * The text that will be shown on the button.
+     */
+    private String display;
+
+    /**
      * The information of the popup (triggered by swipe up).
      */
     @Nullable
     private ExtraKeyButton popup = null;
 
-    /**
-     * The text that will be shown on the button,
-     * if provided by the config.
-     */
-    @Nullable
-    private String displayedTextFromConfig = null;
-
-    /**
-     * The ExtraKeysInfos it belongs to.
-     */
-    private ExtraKeysInfos parent;
-
-    public ExtraKeyButton(ExtraKeysInfos parent, JSONObject config) throws JSONException {
-        this(parent, config, null);
+    public ExtraKeyButton(ExtraKeysInfos.CharDisplayMap charDisplayMap, JSONObject config) throws JSONException {
+        this(charDisplayMap, config, null);
     }
 
-    public ExtraKeyButton(ExtraKeysInfos parent, JSONObject config, ExtraKeyButton popup) throws JSONException {
+    public ExtraKeyButton(ExtraKeysInfos.CharDisplayMap charDisplayMap, JSONObject config, ExtraKeyButton popup) throws JSONException {
         String keyFromConfig = config.optString("key", null);
         String macroFromConfig = config.optString("macro", null);
         if (keyFromConfig != null && macroFromConfig != null) {
@@ -303,8 +297,13 @@ class ExtraKeyButton {
             throw new JSONException("All keys have to specify either key or macro");
         }
 
-        this.displayedTextFromConfig = config.optString("display", null);
-        this.parent = parent;
+        String displayFromConfig = config.optString("display", null);
+        if (displayFromConfig != null) {
+            this.display = displayFromConfig;
+        } else {
+            this.display = charDisplayMap.get(this.key, this.key);
+        }
+
         this.popup = popup;
     }
 
@@ -316,15 +315,12 @@ class ExtraKeyButton {
         return macro;
     }
 
+    public String getDisplay() {
+        return display;
+    }
+
     @Nullable
     public ExtraKeyButton getPopup() {
         return popup;
-    }
-
-    public String getDisplayedText() {
-        if(this.displayedTextFromConfig != null)
-            return this.displayedTextFromConfig;
-        else
-            return parent.getSelectedCharMap().get(key, key);
     }
 }

--- a/app/src/main/java/com/termux/app/ExtraKeysInfos.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysInfos.java
@@ -272,6 +272,11 @@ class ExtraKeyButton {
     private String key;
 
     /**
+     * If the key is a macro, i.e. a sequence of keys separated by space.
+     */
+    private boolean macro;
+
+    /**
      * The information of the popup (triggered by swipe up).
      */
     @Nullable
@@ -294,15 +299,31 @@ class ExtraKeyButton {
     }
 
     public ExtraKeyButton(ExtraKeysInfos parent, JSONObject config, ExtraKeyButton popup) throws JSONException {
-        String keyFromConfig = config.getString("key");
+        String keyFromConfig = config.optString("key", null);
+        String macroFromConfig = config.optString("macro", null);
+        if (keyFromConfig != null && macroFromConfig != null) {
+            throw new JSONException("Both key and macro can't be set for the same key");
+        } else if (keyFromConfig != null) {
+            this.key = ExtraKeysInfos.replaceAlias(keyFromConfig);
+            this.macro = false;
+        } else if (macroFromConfig != null) {
+            this.key = macroFromConfig;
+            this.macro = true;
+        } else {
+            throw new JSONException("All keys have to specify either key or macro");
+        }
+
         this.displayedTextFromConfig = config.optString("display", null);
-        this.key = ExtraKeysInfos.replaceAlias(keyFromConfig);
         this.parent = parent;
         this.popup = popup;
     }
 
     public String getKey() {
         return key;
+    }
+
+    public boolean isMacro() {
+        return macro;
     }
 
     @Nullable

--- a/app/src/main/java/com/termux/app/ExtraKeysInfos.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysInfos.java
@@ -2,6 +2,9 @@ package com.termux.app;
 
 import androidx.annotation.Nullable;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,7 +13,7 @@ public class ExtraKeysInfos {
     /**
      * Matrix of buttons displayed
      */
-    private String [][][] buttons;
+    private ExtraKeyButton[][] buttons;
 
     /**
      * This corresponds to one of the CharMapDisplay below
@@ -22,10 +25,40 @@ public class ExtraKeysInfos {
      */
     private Map<String, String> keyMap;
 
-    public ExtraKeysInfos(String[][][] buttons, Map<String, String> keyMap, String style) {
+    public ExtraKeysInfos(String[][][] buttons, Map<String, String> keyMap, String style) throws Exception {
         this.style = style;
         this.keyMap = keyMap;
-        this.buttons = buttons;
+        this.buttons = new ExtraKeyButton[buttons.length][];
+        for (int i = 0; i < buttons.length; i++) {
+            this.buttons[i] = new ExtraKeyButton[buttons[i].length];
+            for (int j = 0; j < buttons[i].length; j++) {
+                String[] keys = buttons[i][j];
+
+                ExtraKeyButton button;
+
+                if(keys.length == 0) {
+                    throw new Exception("Cannot have empty array.");
+                } else if(keys.length == 1) {
+                    // no popup
+                    button = new ExtraKeyButton(this, keys[0]);
+                } else if(keys.length == 2){
+                    // a popup
+                    button = new ExtraKeyButton(this, keys[0], new ExtraKeyButton(this, keys[1]));
+                } else {
+                    throw new Exception("Too much informations for key.");
+                }
+
+                this.buttons[i][j] = button;
+            }
+        }
+    }
+
+    public ExtraKeyButton[][] getMatrix() {
+        return buttons;
+    }
+
+    public Map<String, String> getKeyMap() {
+        return keyMap;
     }
 
     /**
@@ -94,30 +127,44 @@ public class ExtraKeysInfos {
     }};
 
     /**
-     * Keys are displayed in a natural looking way, like "→" for "RIGHT" or "↲" for ENTER
+     * Multiple maps are available to quickly change
+     * the style of the keys.
      */
-    public static final CharDisplayMap defaultCharDisplay = new CharDisplayMap() {{
+
+    /**
+     * Some classic symbols everybody knows
+     */
+    private static final CharDisplayMap defaultCharDisplay = new CharDisplayMap() {{
         putAll(classicArrowsDisplay);
         putAll(wellKnownCharactersDisplay);
         putAll(nicerLookingDisplay);
         // all other characters are displayed as themselves
     }};
 
-    public static final CharDisplayMap lotsOfArrowsCharDisplay = new CharDisplayMap() {{
+    /**
+     * Classic symbols and less known symbols
+     */
+    private static final CharDisplayMap lotsOfArrowsCharDisplay = new CharDisplayMap() {{
         putAll(classicArrowsDisplay);
         putAll(wellKnownCharactersDisplay);
         putAll(lessKnownCharactersDisplay); // NEW
         putAll(nicerLookingDisplay);
     }};
 
-    public static final CharDisplayMap arrowsOnlyCharDisplay = new CharDisplayMap() {{
+    /**
+     * Only arrows
+     */
+    private static final CharDisplayMap arrowsOnlyCharDisplay = new CharDisplayMap() {{
         putAll(classicArrowsDisplay);
         // putAll(wellKnownCharactersDisplay); // REMOVED
         // putAll(lessKnownCharactersDisplay); // REMOVED
         putAll(nicerLookingDisplay);
     }};
 
-    public static final CharDisplayMap fullIsoCharDisplay = new CharDisplayMap() {{
+    /**
+     * Full Iso
+     */
+    private static final CharDisplayMap fullIsoCharDisplay = new CharDisplayMap() {{
         putAll(classicArrowsDisplay);
         putAll(wellKnownCharactersDisplay);
         putAll(lessKnownCharactersDisplay); // NEW
@@ -128,7 +175,7 @@ public class ExtraKeysInfos {
     /**
      * Some people might call our keys differently
      */
-    static final CharDisplayMap controlCharsAliases = new CharDisplayMap() {{
+    static private final CharDisplayMap controlCharsAliases = new CharDisplayMap() {{
         put("ESCAPE", "ESC");
         put("CONTROL", "CTRL");
         put("RETURN", "ENTER"); // Technically different keys, but most applications won't see the difference
@@ -181,10 +228,55 @@ public class ExtraKeysInfos {
      * Applies the 'controlCharsAliases' mapping to all the strings in *buttons*
      * Modifies the array, doesn't return a new one.
      */
-    public static void replaceAliases(String[][][] buttons) {
-        for(int i = 0; i < buttons.length; i++)
-            for(int j = 0; j < buttons[i].length; j++)
-                for(int k = 0; k < buttons[i][j].length; k++)
-                    buttons[i][j][k] = controlCharsAliases.get(buttons[i][j][k], buttons[i][j][k]);
+    public static String replaceAlias(String key) {
+        return controlCharsAliases.get(key, key);
+    }
+}
+
+class ExtraKeyButton {
+
+    /**
+     * The key that will be sent to the terminal, either a control character
+     * defined in ExtraKeysView.keyCodesForString (LEFT, RIGHT, PGUP...) or
+     * some text.
+     */
+    private String key;
+
+    /**
+     * The information of the popup (triggered by swipe up).
+     */
+    @Nullable
+    private ExtraKeyButton popup = null;
+
+    /**
+     * The ExtraKeysInfos it belongs to.
+     */
+    private ExtraKeysInfos parent;
+
+    public ExtraKeyButton(ExtraKeysInfos parent, String key) {
+        this(parent, key, null);
+    }
+
+    public ExtraKeyButton(ExtraKeysInfos parent, String key, ExtraKeyButton popup) {
+        this.key = ExtraKeysInfos.replaceAlias(key);
+        this.popup = popup;
+        this.parent = parent;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    @Nullable
+    public ExtraKeyButton getPopup() {
+        return popup;
+    }
+
+    public String getDisplayedText() {
+        return parent.getSelectedCharMap().get(getKey(), getKey());
+    }
+
+    public ExtraKeysInfos getParent() {
+        return parent;
     }
 }

--- a/app/src/main/java/com/termux/app/ExtraKeysInfos.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysInfos.java
@@ -4,6 +4,7 @@ import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,32 +26,60 @@ public class ExtraKeysInfos {
      */
     private Map<String, String> keyMap;
 
-    public ExtraKeysInfos(String[][][] buttons, Map<String, String> keyMap, String style) throws Exception {
+    public ExtraKeysInfos(String propertiesInfo, Map<String, String> keyMap, String style) throws JSONException {
         this.style = style;
         this.keyMap = keyMap;
-        this.buttons = new ExtraKeyButton[buttons.length][];
-        for (int i = 0; i < buttons.length; i++) {
-            this.buttons[i] = new ExtraKeyButton[buttons[i].length];
-            for (int j = 0; j < buttons[i].length; j++) {
-                String[] keys = buttons[i][j];
+
+        // Convert String propertiesInfo to Array of Arrays
+        JSONArray arr = new JSONArray(propertiesInfo);
+        Object[][] matrix = new Object[arr.length()][];
+        for (int i = 0; i < arr.length(); i++) {
+            JSONArray line = arr.getJSONArray(i);
+            matrix[i] = new Object[line.length()];
+            for (int j = 0; j < line.length(); j++) {
+                matrix[i][j] = line.get(j);
+            }
+        }
+
+        // convert matrix to buttons
+        this.buttons = new ExtraKeyButton[matrix.length][];
+        for (int i = 0; i < matrix.length; i++) {
+            this.buttons[i] = new ExtraKeyButton[matrix[i].length];
+            for (int j = 0; j < matrix[i].length; j++) {
+                Object key = matrix[i][j];
+
+                JSONObject jobject = normalizeKeyConfig(key);
 
                 ExtraKeyButton button;
 
-                if(keys.length == 0) {
-                    throw new Exception("Cannot have empty array.");
-                } else if(keys.length == 1) {
+                if(! jobject.has("popup")) {
                     // no popup
-                    button = new ExtraKeyButton(this, keys[0]);
-                } else if(keys.length == 2){
-                    // a popup
-                    button = new ExtraKeyButton(this, keys[0], new ExtraKeyButton(this, keys[1]));
+                    button = new ExtraKeyButton(this, jobject);
                 } else {
-                    throw new Exception("Too much informations for key.");
+                    // a popup
+                    JSONObject popupJobject = normalizeKeyConfig(jobject.get("popup"));
+                    button = new ExtraKeyButton(this, jobject, new ExtraKeyButton(this, popupJobject));
                 }
 
                 this.buttons[i][j] = button;
             }
         }
+    }
+
+    /**
+     * "hello" -> {"key": "hello"}
+     */
+    private static JSONObject normalizeKeyConfig(Object key) throws JSONException {
+        JSONObject jobject;
+        if(key instanceof String) {
+            jobject = new JSONObject();
+            jobject.put("key", key);
+        } else if(key instanceof JSONObject) {
+            jobject = (JSONObject) key;
+        } else {
+            throw new JSONException("An key in the extra-key matrix must be a string or an object");
+        }
+        return jobject;
     }
 
     public ExtraKeyButton[][] getMatrix() {
@@ -249,18 +278,27 @@ class ExtraKeyButton {
     private ExtraKeyButton popup = null;
 
     /**
+     * The text that will be shown on the button,
+     * if provided by the config.
+     */
+    @Nullable
+    private String displayedTextFromConfig = null;
+
+    /**
      * The ExtraKeysInfos it belongs to.
      */
     private ExtraKeysInfos parent;
 
-    public ExtraKeyButton(ExtraKeysInfos parent, String key) {
-        this(parent, key, null);
+    public ExtraKeyButton(ExtraKeysInfos parent, JSONObject config) throws JSONException {
+        this(parent, config, null);
     }
 
-    public ExtraKeyButton(ExtraKeysInfos parent, String key, ExtraKeyButton popup) {
-        this.key = ExtraKeysInfos.replaceAlias(key);
-        this.popup = popup;
+    public ExtraKeyButton(ExtraKeysInfos parent, JSONObject config, ExtraKeyButton popup) throws JSONException {
+        String keyFromConfig = config.getString("key");
+        this.displayedTextFromConfig = config.optString("display", null);
+        this.key = ExtraKeysInfos.replaceAlias(keyFromConfig);
         this.parent = parent;
+        this.popup = popup;
     }
 
     public String getKey() {
@@ -273,7 +311,10 @@ class ExtraKeyButton {
     }
 
     public String getDisplayedText() {
-        return parent.getSelectedCharMap().get(getKey(), getKey());
+        if(this.displayedTextFromConfig != null)
+            return this.displayedTextFromConfig;
+        else
+            return parent.getSelectedCharMap().get(key, key);
     }
 
     public ExtraKeysInfos getParent() {

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -276,7 +276,8 @@ public final class ExtraKeysView extends GridLayout {
                         case MotionEvent.ACTION_DOWN:
                             longPressCount = 0;
                             v.setBackgroundColor(BUTTON_PRESSED_COLOR);
-                            if (Arrays.asList("UP", "DOWN", "LEFT", "RIGHT").contains(buttonInfo.getKey())) {
+                            if (Arrays.asList("UP", "DOWN", "LEFT", "RIGHT", "BKSP", "DEL").contains(buttonInfo.getKey())) {
+                                // autorepeat
                                 scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
                                 scheduledExecutor.scheduleWithFixedDelay(() -> {
                                     longPressCount++;

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -96,9 +96,9 @@ public final class ExtraKeysView extends GridLayout {
             // view.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, keyCode));
         } else {
             // not a control char
-            TerminalSession session = terminalView.getCurrentSession();
-            if (session != null && keyName.length() > 0)
-                session.write(keyName);
+            keyName.codePoints().forEach(codePoint -> {
+                terminalView.inputCodePoint(codePoint, false, false);
+            });
         }
     }
 

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -17,6 +17,7 @@ import android.view.HapticFeedbackConstants;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.GridLayout;
 import android.widget.PopupWindow;
@@ -210,6 +211,7 @@ public final class ExtraKeysView extends GridLayout {
         put("TAB", "↹"); // U+21B9 ↹ LEFTWARDS ARROW TO BAR OVER RIGHTWARDS ARROW TO BAR
         put("BKSP", "⌫"); // U+232B ⌫ ERASE TO THE LEFT sometimes seen and easy to understand
         put("DEL", "⌦"); // U+2326 ⌦ ERASE TO THE RIGHT not well known but easy to understand
+        put("KEYBOARD", "⌨"); // U+2328 ⌨ KEYBOARD not well known but easy to understand
     }};
 
     static final CharDisplayMap lessKnownCharactersDisplay = new CharDisplayMap() {{
@@ -419,10 +421,13 @@ public final class ExtraKeysView extends GridLayout {
                     }
 
                     View root = getRootView();
-                    if(Arrays.asList("CTRL", "ALT", "FN").contains(buttonText)) {
+                    if (Arrays.asList("CTRL", "ALT", "FN").contains(buttonText)) {
                         ToggleButton self = (ToggleButton) finalButton;
                         self.setChecked(self.isChecked());
                         self.setTextColor(self.isChecked() ? INTERESTING_COLOR : TEXT_COLOR);
+                    } else if ("KEYBOARD".equals(buttonText)) {
+                        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+                        imm.toggleSoftInput(0, 0);
                     } else {
                         sendKey(root, buttonText, keyMap);
                     }

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -40,7 +40,7 @@ public final class ExtraKeysView extends GridLayout {
     public ExtraKeysView(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
-    
+
     /**
      * HashMap that implements Python dict.get(key, default) function.
      * Default java.util .get(key) is then the same as .get(key, null);
@@ -53,9 +53,9 @@ public final class ExtraKeysView extends GridLayout {
                 return defaultValue;
         }
     }
-    
+
     static class CharDisplayMap extends CleverMap<String, String> {}
-    
+
     /**
      * Keys are displayed in a natural looking way, like "→" for "RIGHT"
      */
@@ -87,7 +87,7 @@ public final class ExtraKeysView extends GridLayout {
         put("F11", KeyEvent.KEYCODE_F11);
         put("F12", KeyEvent.KEYCODE_F12);
     }};
-    
+
     static void sendKey(View view, String keyName) {
         TerminalView terminalView = view.findViewById(R.id.terminal_view);
         if (keyCodesForString.containsKey(keyName)) {
@@ -101,31 +101,31 @@ public final class ExtraKeysView extends GridLayout {
                 session.write(keyName);
         }
     }
-    
+
     public enum SpecialButton {
         CTRL, ALT, FN
     }
-    
+
     private static class SpecialButtonState {
         boolean isOn = false;
         ToggleButton button = null;
     }
-    
+
     private Map<SpecialButton, SpecialButtonState> specialButtons = new HashMap<SpecialButton, SpecialButtonState>() {{
         put(SpecialButton.CTRL, new SpecialButtonState());
         put(SpecialButton.ALT, new SpecialButtonState());
         put(SpecialButton.FN, new SpecialButtonState());
     }};
-    
+
     private ScheduledExecutorService scheduledExecutor;
     private PopupWindow popupWindow;
     private int longPressCount;
-    
+
     public boolean readSpecialButton(SpecialButton name) {
         SpecialButtonState state = specialButtons.get(name);
         if (state == null)
             throw new RuntimeException("Must be a valid special button (see source)");
-        
+
         if (! state.isOn)
             return false;
 
@@ -166,7 +166,7 @@ public final class ExtraKeysView extends GridLayout {
         popupWindow.setFocusable(false);
         popupWindow.showAsDropDown(view, 0, -2 * height);
     }
-    
+
     static final CharDisplayMap classicArrowsDisplay = new CharDisplayMap() {{
         // classic arrow keys (for ◀ ▶ ▲ ▼ @see arrowVariationDisplay) 
         put("LEFT", "←"); // U+2190 ← LEFTWARDS ARROW
@@ -191,7 +191,7 @@ public final class ExtraKeysView extends GridLayout {
         put("PGUP", "⇑"); // no ISO character exists, U+21D1 ⇑ UPWARDS DOUBLE ARROW will do the trick
         put("PGDN", "⇓"); // no ISO character exists, U+21D3 ⇓ DOWNWARDS DOUBLE ARROW will do the trick
     }};
-    
+
     static final CharDisplayMap arrowTriangleVariationDisplay = new CharDisplayMap() {{
         // alternative to classic arrow keys 
         put("LEFT", "◀"); // U+25C0 ◀ BLACK LEFT-POINTING TRIANGLE
@@ -199,7 +199,7 @@ public final class ExtraKeysView extends GridLayout {
         put("UP", "▲"); // U+25B2 ▲ BLACK UP-POINTING TRIANGLE
         put("DOWN", "▼"); // U+25BC ▼ BLACK DOWN-POINTING TRIANGLE
     }};
-    
+
     static final CharDisplayMap notKnownIsoCharacters = new CharDisplayMap() {{
         // Control chars that are more clear as text // https://en.wikipedia.org/wiki/{Function_key, Alt_key, Control_key, Esc_key}
         // put("FN", "FN"); // no ISO character exists
@@ -207,12 +207,12 @@ public final class ExtraKeysView extends GridLayout {
         put("ALT", "⎇"); // ISO character "U+2387 ⎇ ALTERNATIVE KEY SYMBOL'" is unknown to people and only printed as the Option key "⌥" on Mac computer
         put("ESC", "⎋"); // ISO character "U+238B ⎋ BROKEN CIRCLE WITH NORTHWEST ARROW" is unknown to people and not often printed on computers 
     }};
-    
+
     static final CharDisplayMap nicerLookingDisplay = new CharDisplayMap() {{
         // nicer looking for most cases
         put("-", "―"); // U+2015 ― HORIZONTAL BAR
     }};
-    
+
     /**
      * Keys are displayed in a natural looking way, like "→" for "RIGHT" or "↲" for ENTER
      */
@@ -222,21 +222,21 @@ public final class ExtraKeysView extends GridLayout {
         putAll(nicerLookingDisplay);
         // all other characters are displayed as themselves
     }};
-    
+
     public static final CharDisplayMap lotsOfArrowsCharDisplay = new CharDisplayMap() {{
         putAll(classicArrowsDisplay);
         putAll(wellKnownCharactersDisplay);
         putAll(lessKnownCharactersDisplay); // NEW
         putAll(nicerLookingDisplay);
     }};
-    
+
     public static final CharDisplayMap arrowsOnlyCharDisplay = new CharDisplayMap() {{
         putAll(classicArrowsDisplay);
         // putAll(wellKnownCharactersDisplay); // REMOVED
         // putAll(lessKnownCharactersDisplay); // REMOVED
         putAll(nicerLookingDisplay);
     }};
-    
+
     public static final CharDisplayMap fullIsoCharDisplay = new CharDisplayMap() {{
         putAll(classicArrowsDisplay);
         putAll(wellKnownCharactersDisplay);
@@ -244,7 +244,7 @@ public final class ExtraKeysView extends GridLayout {
         putAll(nicerLookingDisplay);
         putAll(notKnownIsoCharacters); // NEW
     }};
-    
+
     /**
      * Some people might call our keys differently
      */
@@ -254,53 +254,54 @@ public final class ExtraKeysView extends GridLayout {
         put("RETURN", "ENTER"); // Technically different keys, but most applications won't see the difference
         put("FUNCTION", "FN");
         // no alias for ALT
-        
+
         // Directions are sometimes written as first and last letter for brevety
         put("LT", "LEFT"); 
         put("RT", "RIGHT");
         put("DN", "DOWN");
         // put("UP", "UP"); well, "UP" is already two letters
-        
+
         put("PAGEUP", "PGUP");
         put("PAGE_UP", "PGUP");
         put("PAGE UP", "PGUP");
         put("PAGE-UP", "PGUP");
-        
+
         // no alias for HOME
         // no alias for END
-        
+
         put("PAGEDOWN", "PGDN");
         put("PAGE_DOWN", "PGDN");
         put("PAGE-DOWN", "PGDN");
-        
+
         put("DELETE", "DEL");
         put("BACKSPACE", "BKSP");
-        
+
         // easier for writing in termux.properties
         put("BACKSLASH", "\\");
         put("QUOTE", "\"");
         put("APOSTROPHE", "'");
     }};
-    
+
     /**
      * Applies the 'controlCharsAliases' mapping to all the strings in *buttons*
      * Modifies the array, doesn't return a new one.
      */
-    void replaceAliases(String[][] buttons) {
+    void replaceAliases(String[][][] buttons) {
         for(int i = 0; i < buttons.length; i++)
             for(int j = 0; j < buttons[i].length; j++)
-                buttons[i][j] = controlCharsAliases.get(buttons[i][j], buttons[i][j]);
+              for(int k = 0; k < buttons[i][j].length; k++)
+                  buttons[i][j][k] = controlCharsAliases.get(buttons[i][j][k], buttons[i][j][k]);
     }
-    
+
     /**
      * General util function to compute the longest column length in a matrix.
      */
-    static int maximumLength(String[][] matrix) {
+    static int maximumLength(String[][][] matrix) {
         int m = 0;
-        for (String[] aMatrix : matrix) m = Math.max(m, aMatrix.length);
+        for (String[][] aMatrix : matrix) m = Math.max(m, aMatrix.length);
         return m;
     }
-    
+
     /**
      * Reload the view given parameters in termux.properties
      *
@@ -316,12 +317,12 @@ public final class ExtraKeysView extends GridLayout {
      * "−" will input a "−" character
      * "-_-" will input the string "-_-"
      */
-    void reload(String[][] buttons, CharDisplayMap charDisplayMap) {
+    void reload(String[][][] buttons, CharDisplayMap charDisplayMap) {
         for(SpecialButtonState state : specialButtons.values())
             state.button = null;
-            
+
         removeAllViews();
-        
+
         replaceAliases(buttons); // modifies the array
 
         final int rows = buttons.length;
@@ -332,8 +333,15 @@ public final class ExtraKeysView extends GridLayout {
 
         for (int row = 0; row < rows; row++) {
             for (int col = 0; col < buttons[row].length; col++) {
-                final String buttonText = buttons[row][col];
-                
+                String[] buttonKeys = buttons[row][col];
+                final String buttonText = buttonKeys[0];
+                final String extraButtonText;
+                if (buttonKeys.length > 1) {
+                    extraButtonText = buttonKeys[1];
+                } else {
+                    extraButtonText = null;
+                }
+
                 Button button;
                 if(Arrays.asList("CTRL", "ALT", "FN").contains(buttonText)) {
                     SpecialButtonState state = specialButtons.get(SpecialButton.valueOf(buttonText)); // for valueOf: https://stackoverflow.com/a/604426/1980630
@@ -343,7 +351,7 @@ public final class ExtraKeysView extends GridLayout {
                 } else {
                     button = new Button(getContext(), null, android.R.attr.buttonBarButtonStyle);
                 }
-                
+
                 final String displayedText = charDisplayMap.get(buttonText, buttonText);
                 button.setText(displayedText);
                 button.setTextColor(TEXT_COLOR);
@@ -390,12 +398,11 @@ public final class ExtraKeysView extends GridLayout {
                             return true;
 
                         case MotionEvent.ACTION_MOVE:
-                            // These two keys have a Move-Up button appearing
-                            if (Arrays.asList("/", "-").contains(buttonText)) {
+                            if (extraButtonText != null) {
                                 if (popupWindow == null && event.getY() < 0) {
                                     v.setBackgroundColor(BUTTON_COLOR);
-                                    String text = "-".equals(buttonText) ? "|" : "\\";
-                                    popup(v, text);
+                                    String extraButtonDisplayedText = charDisplayMap.get(extraButtonText, extraButtonText);
+                                    popup(v, extraButtonDisplayedText);
                                 }
                                 if (popupWindow != null && event.getY() > 0) {
                                     v.setBackgroundColor(BUTTON_PRESSED_COLOR);
@@ -419,11 +426,11 @@ public final class ExtraKeysView extends GridLayout {
                                 scheduledExecutor = null;
                             }
                             if (longPressCount == 0) {
-                                if (popupWindow != null && Arrays.asList("/", "-").contains(buttonText)) {
+                                if (popupWindow != null && extraButtonText != null) {
                                     popupWindow.setContentView(null);
                                     popupWindow.dismiss();
                                     popupWindow = null;
-                                    sendKey(root, "-".equals(buttonText) ? "|" : "\\");
+                                    sendKey(root, extraButtonText);
                                 } else {
                                     v.performClick();
                                 }

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -60,6 +60,7 @@ public final class ExtraKeysView extends GridLayout {
      * Keys are displayed in a natural looking way, like "→" for "RIGHT"
      */
     static final Map<String, Integer> keyCodesForString = new HashMap<String, Integer>() {{
+        put("SPACE", KeyEvent.KEYCODE_SPACE);
         put("ESC", KeyEvent.KEYCODE_ESCAPE);
         put("TAB", KeyEvent.KEYCODE_TAB);
         put("HOME", KeyEvent.KEYCODE_MOVE_HOME);
@@ -99,6 +100,17 @@ public final class ExtraKeysView extends GridLayout {
             keyName.codePoints().forEach(codePoint -> {
                 terminalView.inputCodePoint(codePoint, false, false);
             });
+        }
+    }
+
+    static void sendKey(View view, String keyName, Map<String, String> keyMap) {
+        if (keyMap.containsKey(keyName)) {
+            String[] keys = keyMap.get(keyName).split(" ");
+                for (String key : keys) {
+                    sendKey(view, key);
+                }
+        } else {
+            sendKey(view, keyName);
         }
     }
 
@@ -332,7 +344,7 @@ public final class ExtraKeysView extends GridLayout {
      * "−" will input a "−" character
      * "-_-" will input the string "-_-"
      */
-    void reload(String[][][] buttons, String style) {
+    void reload(String[][][] buttons, String style, Map<String, String> keyMap) {
         for(SpecialButtonState state : specialButtons.values())
             state.button = null;
 
@@ -395,7 +407,7 @@ public final class ExtraKeysView extends GridLayout {
                         self.setChecked(self.isChecked());
                         self.setTextColor(self.isChecked() ? INTERESTING_COLOR : TEXT_COLOR);
                     } else {
-                        sendKey(root, buttonText);
+                        sendKey(root, buttonText, keyMap);
                     }
                 });
 
@@ -409,7 +421,7 @@ public final class ExtraKeysView extends GridLayout {
                                 scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
                                 scheduledExecutor.scheduleWithFixedDelay(() -> {
                                     longPressCount++;
-                                    sendKey(root, buttonText);
+                                    sendKey(root, buttonText, keyMap);
                                 }, 400, 80, TimeUnit.MILLISECONDS);
                             }
                             return true;
@@ -452,7 +464,7 @@ public final class ExtraKeysView extends GridLayout {
                                     popupWindow.dismiss();
                                     popupWindow = null;
                                     if (extraButtonText != null) {
-                                        sendKey(root, extraButtonText);
+                                        sendKey(root, extraButtonText, keyMap);
                                     }
                                 } else {
                                     v.performClick();

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -400,6 +400,10 @@ public final class ExtraKeysView extends GridLayout {
                         case MotionEvent.ACTION_MOVE:
                             if (extraButtonText != null) {
                                 if (popupWindow == null && event.getY() < 0) {
+                                    if (scheduledExecutor != null) {
+                                        scheduledExecutor.shutdownNow();
+                                        scheduledExecutor = null;
+                                    }
                                     v.setBackgroundColor(BUTTON_COLOR);
                                     String extraButtonDisplayedText = charDisplayMap.get(extraButtonText, extraButtonText);
                                     popup(v, extraButtonDisplayedText);
@@ -425,12 +429,14 @@ public final class ExtraKeysView extends GridLayout {
                                 scheduledExecutor.shutdownNow();
                                 scheduledExecutor = null;
                             }
-                            if (longPressCount == 0) {
-                                if (popupWindow != null && extraButtonText != null) {
+                            if (longPressCount == 0 || popupWindow != null) {
+                                if (popupWindow != null) {
                                     popupWindow.setContentView(null);
                                     popupWindow.dismiss();
                                     popupWindow = null;
-                                    sendKey(root, extraButtonText);
+                                    if (extraButtonText != null) {
+                                        sendKey(root, extraButtonText);
+                                    }
                                 } else {
                                     v.performClick();
                                 }

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -302,6 +302,21 @@ public final class ExtraKeysView extends GridLayout {
         return m;
     }
 
+    private CharDisplayMap getStyle(String style) {
+        switch (style) {
+            case "arrows-only":
+                return arrowsOnlyCharDisplay;
+            case "arrows-all":
+                return lotsOfArrowsCharDisplay;
+            case "all":
+                return fullIsoCharDisplay;
+            case "none":
+                return new CharDisplayMap();
+            default:
+                return defaultCharDisplay;
+        }
+    }
+
     /**
      * Reload the view given parameters in termux.properties
      *
@@ -317,11 +332,13 @@ public final class ExtraKeysView extends GridLayout {
      * "−" will input a "−" character
      * "-_-" will input the string "-_-"
      */
-    void reload(String[][][] buttons, CharDisplayMap charDisplayMap) {
+    void reload(String[][][] buttons, String style) {
         for(SpecialButtonState state : specialButtons.values())
             state.button = null;
 
         removeAllViews();
+
+        CharDisplayMap charDisplayMap = getStyle(style);
 
         replaceAliases(buttons); // modifies the array
 

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -211,6 +211,9 @@ public final class ExtraKeysView extends GridLayout {
      */
     @SuppressLint("ClickableViewAccessibility")
     void reload(ExtraKeysInfos infos) {
+        if(infos == null)
+            return;
+
         for(SpecialButtonState state : specialButtons.values())
             state.button = null;
 

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -94,17 +94,8 @@ public final class ExtraKeysView extends GridLayout {
     }
 
     static void sendKey(View view, ExtraKeyButton buttonInfo) {
-        Map<String, String> keyMap = buttonInfo.getParent().getKeyMap();
-        String keyName = buttonInfo.getKey();
-        boolean isMacro = buttonInfo.isMacro();
-
-        if (keyMap.containsKey(keyName)) {
-            keyName = keyMap.get(keyName);
-            isMacro = true;
-        }
-
-        if (isMacro) {
-            String[] keys = keyName.split(" ");
+        if (buttonInfo.isMacro()) {
+            String[] keys = buttonInfo.getKey().split(" ");
             boolean ctrlDown = false;
             boolean altDown = false;
             for (String key : keys) {
@@ -119,7 +110,7 @@ public final class ExtraKeysView extends GridLayout {
                 }
             }
         } else {
-            sendKey(view, keyName, false, false);
+            sendKey(view, buttonInfo.getKey(), false, false);
         }
     }
 

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -72,9 +72,12 @@ public final class ExtraKeysView extends GridLayout {
         put("F12", KeyEvent.KEYCODE_F12);
     }};
 
-    static void sendKey(View view, String keyName, boolean forceCtrlDown, boolean forceLeftAltDown) {
+    private void sendKey(View view, String keyName, boolean forceCtrlDown, boolean forceLeftAltDown) {
         TerminalView terminalView = view.findViewById(R.id.terminal_view);
-        if (keyCodesForString.containsKey(keyName)) {
+        if ("KEYBOARD".equals(keyName)) {
+            InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.toggleSoftInput(0, 0);
+        } else if (keyCodesForString.containsKey(keyName)) {
             int keyCode = keyCodesForString.get(keyName);
             int metaState = 0;
             if (forceCtrlDown) {
@@ -93,7 +96,7 @@ public final class ExtraKeysView extends GridLayout {
         }
     }
 
-    static void sendKey(View view, ExtraKeyButton buttonInfo) {
+    private void sendKey(View view, ExtraKeyButton buttonInfo) {
         if (buttonInfo.isMacro()) {
             String[] keys = buttonInfo.getKey().split(" ");
             boolean ctrlDown = false;
@@ -257,9 +260,6 @@ public final class ExtraKeysView extends GridLayout {
                         ToggleButton self = (ToggleButton) finalButton;
                         self.setChecked(self.isChecked());
                         self.setTextColor(self.isChecked() ? INTERESTING_COLOR : TEXT_COLOR);
-                    } else if ("KEYBOARD".equals(buttonInfo.getKey())) {
-                        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-                        imm.toggleSoftInput(0, 0);
                     } else {
                         sendKey(root, buttonInfo);
                     }

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -1,5 +1,6 @@
 package com.termux.app;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Build;
 import android.provider.Settings;
@@ -24,7 +25,6 @@ import android.widget.PopupWindow;
 import android.widget.ToggleButton;
 
 import com.termux.R;
-import com.termux.terminal.TerminalSession;
 import com.termux.view.TerminalView;
 
 /**
@@ -42,24 +42,6 @@ public final class ExtraKeysView extends GridLayout {
         super(context, attrs);
     }
 
-    /**
-     * HashMap that implements Python dict.get(key, default) function.
-     * Default java.util .get(key) is then the same as .get(key, null);
-     */
-    static class CleverMap<K,V> extends HashMap<K,V> {
-        V get(K key, V defaultValue) {
-            if(containsKey(key))
-                return get(key);
-            else
-                return defaultValue;
-        }
-    }
-
-    static class CharDisplayMap extends CleverMap<String, String> {}
-
-    /**
-     * Keys are displayed in a natural looking way, like "→" for "RIGHT"
-     */
     static final Map<String, Integer> keyCodesForString = new HashMap<String, Integer>() {{
         put("SPACE", KeyEvent.KEYCODE_SPACE);
         put("ESC", KeyEvent.KEYCODE_ESCAPE);
@@ -197,133 +179,6 @@ public final class ExtraKeysView extends GridLayout {
         popupWindow.showAsDropDown(view, 0, -2 * height);
     }
 
-    static final CharDisplayMap classicArrowsDisplay = new CharDisplayMap() {{
-        // classic arrow keys (for ◀ ▶ ▲ ▼ @see arrowVariationDisplay) 
-        put("LEFT", "←"); // U+2190 ← LEFTWARDS ARROW
-        put("RIGHT", "→"); // U+2192 → RIGHTWARDS ARROW
-        put("UP", "↑"); // U+2191 ↑ UPWARDS ARROW
-        put("DOWN", "↓"); // U+2193 ↓ DOWNWARDS ARROW
-    }};
-
-    static final CharDisplayMap wellKnownCharactersDisplay = new CharDisplayMap() {{
-        // well known characters // https://en.wikipedia.org/wiki/{Enter_key, Tab_key, Delete_key}
-        put("ENTER", "↲"); // U+21B2 ↲ DOWNWARDS ARROW WITH TIP LEFTWARDS
-        put("TAB", "↹"); // U+21B9 ↹ LEFTWARDS ARROW TO BAR OVER RIGHTWARDS ARROW TO BAR
-        put("BKSP", "⌫"); // U+232B ⌫ ERASE TO THE LEFT sometimes seen and easy to understand
-        put("DEL", "⌦"); // U+2326 ⌦ ERASE TO THE RIGHT not well known but easy to understand
-        put("KEYBOARD", "⌨"); // U+2328 ⌨ KEYBOARD not well known but easy to understand
-    }};
-
-    static final CharDisplayMap lessKnownCharactersDisplay = new CharDisplayMap() {{
-        // https://en.wikipedia.org/wiki/{Home_key, End_key, Page_Up_and_Page_Down_keys}
-        // home key can mean "goto the beginning of line" or "goto first page" depending on context, hence the diagonal
-        put("HOME", "⇱"); // from IEC 9995 // U+21F1 ⇱ NORTH WEST ARROW TO CORNER
-        put("END", "⇲"); // from IEC 9995 // ⇲ // U+21F2 ⇲ SOUTH EAST ARROW TO CORNER
-        put("PGUP", "⇑"); // no ISO character exists, U+21D1 ⇑ UPWARDS DOUBLE ARROW will do the trick
-        put("PGDN", "⇓"); // no ISO character exists, U+21D3 ⇓ DOWNWARDS DOUBLE ARROW will do the trick
-    }};
-
-    static final CharDisplayMap arrowTriangleVariationDisplay = new CharDisplayMap() {{
-        // alternative to classic arrow keys 
-        put("LEFT", "◀"); // U+25C0 ◀ BLACK LEFT-POINTING TRIANGLE
-        put("RIGHT", "▶"); // U+25B6 ▶ BLACK RIGHT-POINTING TRIANGLE
-        put("UP", "▲"); // U+25B2 ▲ BLACK UP-POINTING TRIANGLE
-        put("DOWN", "▼"); // U+25BC ▼ BLACK DOWN-POINTING TRIANGLE
-    }};
-
-    static final CharDisplayMap notKnownIsoCharacters = new CharDisplayMap() {{
-        // Control chars that are more clear as text // https://en.wikipedia.org/wiki/{Function_key, Alt_key, Control_key, Esc_key}
-        // put("FN", "FN"); // no ISO character exists
-        put("CTRL", "⎈"); // ISO character "U+2388 ⎈ HELM SYMBOL" is unknown to people and never printed on computers, however "U+25C7 ◇ WHITE DIAMOND" is a nice presentation, and "^" for terminal app and mac is often used 
-        put("ALT", "⎇"); // ISO character "U+2387 ⎇ ALTERNATIVE KEY SYMBOL'" is unknown to people and only printed as the Option key "⌥" on Mac computer
-        put("ESC", "⎋"); // ISO character "U+238B ⎋ BROKEN CIRCLE WITH NORTHWEST ARROW" is unknown to people and not often printed on computers 
-    }};
-
-    static final CharDisplayMap nicerLookingDisplay = new CharDisplayMap() {{
-        // nicer looking for most cases
-        put("-", "―"); // U+2015 ― HORIZONTAL BAR
-    }};
-
-    /**
-     * Keys are displayed in a natural looking way, like "→" for "RIGHT" or "↲" for ENTER
-     */
-    public static final CharDisplayMap defaultCharDisplay = new CharDisplayMap() {{
-        putAll(classicArrowsDisplay);
-        putAll(wellKnownCharactersDisplay);
-        putAll(nicerLookingDisplay);
-        // all other characters are displayed as themselves
-    }};
-
-    public static final CharDisplayMap lotsOfArrowsCharDisplay = new CharDisplayMap() {{
-        putAll(classicArrowsDisplay);
-        putAll(wellKnownCharactersDisplay);
-        putAll(lessKnownCharactersDisplay); // NEW
-        putAll(nicerLookingDisplay);
-    }};
-
-    public static final CharDisplayMap arrowsOnlyCharDisplay = new CharDisplayMap() {{
-        putAll(classicArrowsDisplay);
-        // putAll(wellKnownCharactersDisplay); // REMOVED
-        // putAll(lessKnownCharactersDisplay); // REMOVED
-        putAll(nicerLookingDisplay);
-    }};
-
-    public static final CharDisplayMap fullIsoCharDisplay = new CharDisplayMap() {{
-        putAll(classicArrowsDisplay);
-        putAll(wellKnownCharactersDisplay);
-        putAll(lessKnownCharactersDisplay); // NEW
-        putAll(nicerLookingDisplay);
-        putAll(notKnownIsoCharacters); // NEW
-    }};
-
-    /**
-     * Some people might call our keys differently
-     */
-    static final CharDisplayMap controlCharsAliases = new CharDisplayMap() {{
-        put("ESCAPE", "ESC");
-        put("CONTROL", "CTRL");
-        put("RETURN", "ENTER"); // Technically different keys, but most applications won't see the difference
-        put("FUNCTION", "FN");
-        // no alias for ALT
-
-        // Directions are sometimes written as first and last letter for brevety
-        put("LT", "LEFT"); 
-        put("RT", "RIGHT");
-        put("DN", "DOWN");
-        // put("UP", "UP"); well, "UP" is already two letters
-
-        put("PAGEUP", "PGUP");
-        put("PAGE_UP", "PGUP");
-        put("PAGE UP", "PGUP");
-        put("PAGE-UP", "PGUP");
-
-        // no alias for HOME
-        // no alias for END
-
-        put("PAGEDOWN", "PGDN");
-        put("PAGE_DOWN", "PGDN");
-        put("PAGE-DOWN", "PGDN");
-
-        put("DELETE", "DEL");
-        put("BACKSPACE", "BKSP");
-
-        // easier for writing in termux.properties
-        put("BACKSLASH", "\\");
-        put("QUOTE", "\"");
-        put("APOSTROPHE", "'");
-    }};
-
-    /**
-     * Applies the 'controlCharsAliases' mapping to all the strings in *buttons*
-     * Modifies the array, doesn't return a new one.
-     */
-    void replaceAliases(String[][][] buttons) {
-        for(int i = 0; i < buttons.length; i++)
-            for(int j = 0; j < buttons[i].length; j++)
-              for(int k = 0; k < buttons[i][j].length; k++)
-                  buttons[i][j][k] = controlCharsAliases.get(buttons[i][j][k], buttons[i][j][k]);
-    }
-
     /**
      * General util function to compute the longest column length in a matrix.
      */
@@ -331,21 +186,6 @@ public final class ExtraKeysView extends GridLayout {
         int m = 0;
         for (String[][] aMatrix : matrix) m = Math.max(m, aMatrix.length);
         return m;
-    }
-
-    private CharDisplayMap getStyle(String style) {
-        switch (style) {
-            case "arrows-only":
-                return arrowsOnlyCharDisplay;
-            case "arrows-all":
-                return lotsOfArrowsCharDisplay;
-            case "all":
-                return fullIsoCharDisplay;
-            case "none":
-                return new CharDisplayMap();
-            default:
-                return defaultCharDisplay;
-        }
     }
 
     /**
@@ -363,15 +203,17 @@ public final class ExtraKeysView extends GridLayout {
      * "−" will input a "−" character
      * "-_-" will input the string "-_-"
      */
+    @SuppressLint("ClickableViewAccessibility")
     void reload(String[][][] buttons, String style, Map<String, String> keyMap) {
         for(SpecialButtonState state : specialButtons.values())
             state.button = null;
 
         removeAllViews();
 
-        CharDisplayMap charDisplayMap = getStyle(style);
+        ExtraKeysInfos infos = new ExtraKeysInfos(buttons, keyMap, style);
+        ExtraKeysInfos.CharDisplayMap charDisplayMap = infos.getSelectedCharMap();
 
-        replaceAliases(buttons); // modifies the array
+        infos.replaceAliases(buttons); // modifies the array
 
         final int rows = buttons.length;
         final int cols = maximumLength(buttons);

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -233,7 +233,7 @@ public final class ExtraKeysView extends GridLayout {
                     button = new Button(getContext(), null, android.R.attr.buttonBarButtonStyle);
                 }
 
-                button.setText(buttonInfo.getDisplayedText());
+                button.setText(buttonInfo.getDisplay());
                 button.setTextColor(TEXT_COLOR);
                 button.setPadding(0, 0, 0, 0);
 
@@ -289,7 +289,7 @@ public final class ExtraKeysView extends GridLayout {
                                         scheduledExecutor = null;
                                     }
                                     v.setBackgroundColor(BUTTON_COLOR);
-                                    String extraButtonDisplayedText = buttonInfo.getPopup().getDisplayedText();
+                                    String extraButtonDisplayedText = buttonInfo.getPopup().getDisplay();
                                     popup(v, extraButtonDisplayedText);
                                 }
                                 if (popupWindow != null && event.getY() > 0) {

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Arrays;
 
+import android.view.Gravity;
 import android.view.HapticFeedbackConstants;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -26,6 +27,8 @@ import android.widget.ToggleButton;
 
 import com.termux.R;
 import com.termux.view.TerminalView;
+
+import androidx.drawerlayout.widget.DrawerLayout;
 
 /**
  * A view showing extra keys (such as Escape, Ctrl, Alt) not normally available on an Android soft
@@ -77,6 +80,9 @@ public final class ExtraKeysView extends GridLayout {
         if ("KEYBOARD".equals(keyName)) {
             InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
             imm.toggleSoftInput(0, 0);
+        } else if ("DRAWER".equals(keyName)) {
+            DrawerLayout drawer = view.findViewById(R.id.drawer_layout);
+            drawer.openDrawer(Gravity.LEFT);
         } else if (keyCodesForString.containsKey(keyName)) {
             int keyCode = keyCodesForString.get(keyName);
             int metaState = 0;

--- a/app/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/app/src/main/java/com/termux/app/ExtraKeysView.java
@@ -96,10 +96,15 @@ public final class ExtraKeysView extends GridLayout {
     static void sendKey(View view, ExtraKeyButton buttonInfo) {
         Map<String, String> keyMap = buttonInfo.getParent().getKeyMap();
         String keyName = buttonInfo.getKey();
+        boolean isMacro = buttonInfo.isMacro();
 
         if (keyMap.containsKey(keyName)) {
-            // it's a macro
-            String[] keys = keyMap.get(keyName).split(" ");
+            keyName = keyMap.get(keyName);
+            isMacro = true;
+        }
+
+        if (isMacro) {
+            String[] keys = keyName.split(" ");
             boolean ctrlDown = false;
             boolean altDown = false;
             for (String key : keys) {
@@ -114,7 +119,6 @@ public final class ExtraKeysView extends GridLayout {
                 }
             }
         } else {
-            // it's a single key
             sendKey(view, keyName, false, false);
         }
     }

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -148,7 +148,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 mSettings.reloadFromProperties(TermuxActivity.this);
 
                 if (mExtraKeysView != null) {
-                    mExtraKeysView.reload(mSettings.mExtraKeys, mSettings.mExtraKeysStyle);
+                    mExtraKeysView.reload(mSettings.mExtraKeys, mSettings.mExtraKeysStyle, mSettings.mExtraKeysMap);
                 }
             }
         }
@@ -250,7 +250,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 View layout;
                 if (position == 0) {
                     layout = mExtraKeysView = (ExtraKeysView) inflater.inflate(R.layout.extra_keys_main, collection, false);
-                    mExtraKeysView.reload(mSettings.mExtraKeys, mSettings.mExtraKeysStyle);
+                    mExtraKeysView.reload(mSettings.mExtraKeys, mSettings.mExtraKeysStyle, mSettings.mExtraKeysMap);
                 } else {
                     layout = inflater.inflate(R.layout.extra_keys_right, collection, false);
                     final EditText editText = layout.findViewById(R.id.text_input);

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -148,7 +148,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 mSettings.reloadFromProperties(TermuxActivity.this);
 
                 if (mExtraKeysView != null) {
-                    mExtraKeysView.reload(mSettings.mExtraKeys, mSettings.mExtraKeysStyle, mSettings.mExtraKeysMap);
+                    mExtraKeysView.reload(mSettings.mExtraKeys);
                 }
             }
         }
@@ -229,7 +229,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
 
 
         ViewGroup.LayoutParams layoutParams = viewPager.getLayoutParams();
-        layoutParams.height = layoutParams.height * mSettings.mExtraKeys.length;
+        layoutParams.height = layoutParams.height * (mSettings.mExtraKeys == null ? 0 : mSettings.mExtraKeys.getMatrix().length);
         viewPager.setLayoutParams(layoutParams);
 
         viewPager.setAdapter(new PagerAdapter() {
@@ -250,7 +250,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 View layout;
                 if (position == 0) {
                     layout = mExtraKeysView = (ExtraKeysView) inflater.inflate(R.layout.extra_keys_main, collection, false);
-                    mExtraKeysView.reload(mSettings.mExtraKeys, mSettings.mExtraKeysStyle, mSettings.mExtraKeysMap);
+                    mExtraKeysView.reload(mSettings.mExtraKeys);
                 } else {
                     layout = inflater.inflate(R.layout.extra_keys_right, collection, false);
                     final EditText editText = layout.findViewById(R.id.text_input);

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -148,7 +148,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 mSettings.reloadFromProperties(TermuxActivity.this);
 
                 if (mExtraKeysView != null) {
-                    mExtraKeysView.reload(mSettings.mExtraKeys, ExtraKeysView.defaultCharDisplay);
+                    mExtraKeysView.reload(mSettings.mExtraKeys, mSettings.mExtraKeysStyle);
                 }
             }
         }
@@ -250,7 +250,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 View layout;
                 if (position == 0) {
                     layout = mExtraKeysView = (ExtraKeysView) inflater.inflate(R.layout.extra_keys_main, collection, false);
-                    mExtraKeysView.reload(mSettings.mExtraKeys, ExtraKeysView.defaultCharDisplay);
+                    mExtraKeysView.reload(mSettings.mExtraKeys, mSettings.mExtraKeysStyle);
                 } else {
                     layout = inflater.inflate(R.layout.extra_keys_right, collection, false);
                     final EditText editText = layout.findViewById(R.id.text_input);

--- a/app/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/app/src/main/java/com/termux/app/TermuxPreferences.java
@@ -9,6 +9,7 @@ import android.widget.Toast;
 import com.termux.terminal.TerminalSession;
 import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -18,7 +19,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import androidx.annotation.IntDef;
@@ -71,6 +75,7 @@ final class TermuxPreferences {
 
     String[][][] mExtraKeys;
     String mExtraKeysStyle;
+    Map<String, String> mExtraKeysMap;
 
     final List<KeyboardShortcut> shortcuts = new ArrayList<>();
 
@@ -206,6 +211,19 @@ final class TermuxPreferences {
             Toast.makeText(context, "Could not load the extra-keys property from the config: " + e.toString(), Toast.LENGTH_LONG).show();
             Log.e("termux", "Error loading props", e);
             mExtraKeys = new String[0][][];
+        }
+
+        mExtraKeysMap = new HashMap<>();
+        try {
+            JSONObject obj = new JSONObject(props.getProperty("extra-keys-map", "{}"));
+            Iterator<String> keys = obj.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                mExtraKeysMap.put(key, obj.getString(key));
+            }
+        } catch (JSONException e) {
+            Toast.makeText(context, "Could not load the extra-keys-map property from the config: " + e.toString(), Toast.LENGTH_LONG).show();
+            Log.e("termux", "Error loading props", e);
         }
 
         mBackIsEscape = "escape".equals(props.getProperty("back-key", "back"));

--- a/app/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/app/src/main/java/com/termux/app/TermuxPreferences.java
@@ -70,6 +70,7 @@ final class TermuxPreferences {
     boolean mShowExtraKeys;
 
     String[][][] mExtraKeys;
+    String mExtraKeysStyle;
 
     final List<KeyboardShortcut> shortcuts = new ArrayList<>();
 
@@ -209,6 +210,7 @@ final class TermuxPreferences {
 
         mBackIsEscape = "escape".equals(props.getProperty("back-key", "back"));
         mDisableVolumeVirtualKeys = "volume".equals(props.getProperty("volume-keys", "virtual"));
+        mExtraKeysStyle = props.getProperty("extra-keys-style", "default");
 
         shortcuts.clear();
         parseAction("shortcut.create-session", SHORTCUT_ACTION_CREATE_SESSION, props);

--- a/app/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/app/src/main/java/com/termux/app/TermuxPreferences.java
@@ -69,7 +69,7 @@ final class TermuxPreferences {
     boolean mDisableVolumeVirtualKeys;
     boolean mShowExtraKeys;
 
-    String[][] mExtraKeys;
+    String[][][] mExtraKeys;
 
     final List<KeyboardShortcut> shortcuts = new ArrayList<>();
 
@@ -182,20 +182,29 @@ final class TermuxPreferences {
         mUseDarkUI = props.getProperty("use-black-ui", "false");
 
         try {
-            JSONArray arr = new JSONArray(props.getProperty("extra-keys", "[['ESC', 'TAB', 'CTRL', 'ALT', '-', 'DOWN', 'UP']]"));
+            JSONArray arr = new JSONArray(props.getProperty("extra-keys", "[['ESC', 'TAB', 'CTRL', 'ALT', ['-', '|'], 'DOWN', 'UP']]"));
 
-            mExtraKeys = new String[arr.length()][];
+            mExtraKeys = new String[arr.length()][][];
             for (int i = 0; i < arr.length(); i++) {
                 JSONArray line = arr.getJSONArray(i);
-                mExtraKeys[i] = new String[line.length()];
+                mExtraKeys[i] = new String[line.length()][];
                 for (int j = 0; j < line.length(); j++) {
-                    mExtraKeys[i][j] = line.getString(j);
+                    JSONArray key = line.optJSONArray(j);
+                    if (key != null && key.length() > 0) {
+                        mExtraKeys[i][j] = new String[key.length()];
+                        for (int k = 0; k < key.length(); k++) {
+                            mExtraKeys[i][j][k] = key.getString(k);
+                        }
+                    } else {
+                        mExtraKeys[i][j] = new String[]{line.getString(j)};
+                    }
                 }
             }
+
         } catch (JSONException e) {
             Toast.makeText(context, "Could not load the extra-keys property from the config: " + e.toString(), Toast.LENGTH_LONG).show();
             Log.e("termux", "Error loading props", e);
-            mExtraKeys = new String[0][];
+            mExtraKeys = new String[0][][];
         }
 
         mBackIsEscape = "escape".equals(props.getProperty("back-key", "back"));

--- a/app/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/app/src/main/java/com/termux/app/TermuxPreferences.java
@@ -189,27 +189,17 @@ final class TermuxPreferences {
 
         try {
             String extrakeyProp = props.getProperty("extra-keys", defaultExtraKeys);
-
-            Map<String, String> extraKeysMap = new HashMap<>();
-            JSONObject obj = new JSONObject(props.getProperty("extra-keys-map", "{}"));
-            Iterator<String> keys = obj.keys();
-            while (keys.hasNext()) {
-                String key = keys.next();
-                extraKeysMap.put(key, obj.getString(key));
-            }
-
             String extraKeysStyle = props.getProperty("extra-keys-style", "default");
-
-            mExtraKeys = new ExtraKeysInfos(extrakeyProp, extraKeysMap, extraKeysStyle);
+            mExtraKeys = new ExtraKeysInfos(extrakeyProp, extraKeysStyle);
         } catch (JSONException e) {
             Toast.makeText(context, "Could not load the extra-keys property from the config: " + e.toString(), Toast.LENGTH_LONG).show();
             Log.e("termux", "Error loading props", e);
 
             try {
-                mExtraKeys = new ExtraKeysInfos(defaultExtraKeys, new HashMap<>(), "default");
+                mExtraKeys = new ExtraKeysInfos(defaultExtraKeys, "default");
             } catch (JSONException e2) {
                 e2.printStackTrace();
-                Toast.makeText(context, "Can't create default keyMap", Toast.LENGTH_LONG).show();
+                Toast.makeText(context, "Can't create default extra keys", Toast.LENGTH_LONG).show();
                 mExtraKeys = null;
             }
         }

--- a/app/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/app/src/main/java/com/termux/app/TermuxPreferences.java
@@ -153,27 +153,6 @@ final class TermuxPreferences {
         }
         return null;
     }
-    
-    private static String[][][] parseExtraKeysFromString(String string) throws JSONException {
-        JSONArray arr = new JSONArray(string);
-        String[][][] matrix = new String[arr.length()][][];
-        for (int i = 0; i < arr.length(); i++) {
-            JSONArray line = arr.getJSONArray(i);
-            matrix[i] = new String[line.length()][];
-            for (int j = 0; j < line.length(); j++) {
-                JSONArray key = line.optJSONArray(j);
-                if (key != null && key.length() > 0) {
-                    matrix[i][j] = new String[key.length()];
-                    for (int k = 0; k < key.length(); k++) {
-                        matrix[i][j][k] = key.getString(k);
-                    }
-                } else {
-                    matrix[i][j] = new String[]{line.getString(j)};
-                }
-            }
-        }
-        return matrix;
-    }
 
     void reloadFromProperties(Context context) {
         File propsFile = new File(TermuxService.HOME_PATH + "/.termux/termux.properties");
@@ -206,45 +185,29 @@ final class TermuxPreferences {
 
         mUseDarkUI = props.getProperty("use-black-ui", "false");
 
-        final String[][][] defaultExtraKeys = {{{"ESC"}, {"TAB"}, {"CTRL"}, {"ALT"}, {"-", "|"}, {"DOWN"}, {"UP"}}};
+        String defaultExtraKeys = "[[ESC, TAB, CTRL, ALT, {key: '-', popup: '|'}, DOWN, UP]]";
 
-        String[][][] extraKeysMatrix = defaultExtraKeys;
-
-        String prop = props.getProperty("extra-keys");
-        if (prop != null) {
-            try {
-                extraKeysMatrix = parseExtraKeysFromString(prop);
-            } catch (JSONException e) {
-                Toast.makeText(context, "Could not load the extra-keys property from the config: " + e.toString(), Toast.LENGTH_LONG).show();
-                Log.e("termux", "Error loading props", e);
-                // the default will be used
-            }
-        }
-
-        Map<String, String> extraKeysMap = new HashMap<>();
         try {
+            String extrakeyProp = props.getProperty("extra-keys", defaultExtraKeys);
+
+            Map<String, String> extraKeysMap = new HashMap<>();
             JSONObject obj = new JSONObject(props.getProperty("extra-keys-map", "{}"));
             Iterator<String> keys = obj.keys();
             while (keys.hasNext()) {
                 String key = keys.next();
                 extraKeysMap.put(key, obj.getString(key));
             }
+
+            String extraKeysStyle = props.getProperty("extra-keys-style", "default");
+
+            mExtraKeys = new ExtraKeysInfos(extrakeyProp, extraKeysMap, extraKeysStyle);
         } catch (JSONException e) {
-            Toast.makeText(context, "Could not load the extra-keys-map property from the config: " + e.toString(), Toast.LENGTH_LONG).show();
-            Log.e("termux", "Error loading props", e);
-        }
-
-        String extraKeysStyle = props.getProperty("extra-keys-style", "default");
-
-        try {
-            mExtraKeys = new ExtraKeysInfos(extraKeysMatrix, extraKeysMap, extraKeysStyle);
-        } catch (Exception e) {
             Toast.makeText(context, "Could not load the extra-keys property from the config: " + e.toString(), Toast.LENGTH_LONG).show();
             Log.e("termux", "Error loading props", e);
 
             try {
                 mExtraKeys = new ExtraKeysInfos(defaultExtraKeys, new HashMap<>(), "default");
-            } catch (Exception e2) {
+            } catch (JSONException e2) {
                 e2.printStackTrace();
                 Toast.makeText(context, "Can't create default keyMap", Toast.LENGTH_LONG).show();
                 mExtraKeys = null;

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.3'
     }
 }
 

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -558,13 +558,13 @@ public final class TerminalView extends View {
         }
 
         final int metaState = event.getMetaState();
-        final boolean controlDownFromEvent = event.isCtrlPressed();
-        final boolean leftAltDownFromEvent = (metaState & KeyEvent.META_ALT_LEFT_ON) != 0;
+        final boolean controlDown = event.isCtrlPressed() || mClient.readControlKey();
+        final boolean leftAltDown = (metaState & KeyEvent.META_ALT_LEFT_ON) != 0 || mClient.readAltKey();
         final boolean rightAltDownFromEvent = (metaState & KeyEvent.META_ALT_RIGHT_ON) != 0;
 
         int keyMod = 0;
-        if (controlDownFromEvent) keyMod |= KeyHandler.KEYMOD_CTRL;
-        if (event.isAltPressed()) keyMod |= KeyHandler.KEYMOD_ALT;
+        if (controlDown) keyMod |= KeyHandler.KEYMOD_CTRL;
+        if (event.isAltPressed() || leftAltDown) keyMod |= KeyHandler.KEYMOD_ALT;
         if (event.isShiftPressed()) keyMod |= KeyHandler.KEYMOD_SHIFT;
         if (!event.isFunctionPressed() && handleKeyCode(keyCode, keyMod)) {
             if (LOG_KEY_EVENTS) Log.i(EmulatorDebug.LOG_TAG, "handleKeyCode() took key event");
@@ -592,7 +592,7 @@ public final class TerminalView extends View {
         if ((result & KeyCharacterMap.COMBINING_ACCENT) != 0) {
             // If entered combining accent previously, write it out:
             if (mCombiningAccent != 0)
-                inputCodePoint(mCombiningAccent, controlDownFromEvent, leftAltDownFromEvent);
+                inputCodePoint(mCombiningAccent, controlDown, leftAltDown);
             mCombiningAccent = result & KeyCharacterMap.COMBINING_ACCENT_MASK;
         } else {
             if (mCombiningAccent != 0) {
@@ -600,7 +600,7 @@ public final class TerminalView extends View {
                 if (combinedChar > 0) result = combinedChar;
                 mCombiningAccent = 0;
             }
-            inputCodePoint(result, controlDownFromEvent, leftAltDownFromEvent);
+            inputCodePoint(result, controlDown, leftAltDown);
         }
 
         if (mCombiningAccent != oldCombiningAccent) invalidate();

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -608,7 +608,7 @@ public final class TerminalView extends View {
         return true;
     }
 
-    void inputCodePoint(int codePoint, boolean controlDownFromEvent, boolean leftAltDownFromEvent) {
+    public void inputCodePoint(int codePoint, boolean controlDownFromEvent, boolean leftAltDownFromEvent) {
         if (LOG_KEY_EVENTS) {
             Log.i(EmulatorDebug.LOG_TAG, "inputCodePoint(codePoint=" + codePoint + ", controlDownFromEvent=" + controlDownFromEvent + ", leftAltDownFromEvent="
                 + leftAltDownFromEvent + ")");


### PR DESCRIPTION
This adds support for multiple things for the extra keys.

- The popup keys are now configurable
- The style can be configured, e.g. if PGUP should be shown as text or an arrow character etc.
- Modifier keys can now be used with the other keys on the extra keys rows.
- Keys can be mapped to other and multiple actions. This allows you to use whatever text you want on the button for an action, and it also allows you to define macros.

See the commit messages for more details.