### PR TITLE
Handle all exceptions when loading termux.properties

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/app/src/main/java/com/termux/app/TermuxPreferences.java
@@ -163,7 +163,7 @@ final class TermuxPreferences {
                 }
             }
         } catch (Exception e) {
-            Toast.makeText(context, "Could not open properties file termux.properties.", Toast.LENGTH_LONG).show();
+            Toast.makeText(context, "Could not open properties file termux.properties: " + e.getMessage(), Toast.LENGTH_LONG).show();
             Log.e("termux", "Error loading props", e);
         }
 

--- a/app/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/app/src/main/java/com/termux/app/TermuxPreferences.java
@@ -162,7 +162,7 @@ final class TermuxPreferences {
                     props.load(new InputStreamReader(in, StandardCharsets.UTF_8));
                 }
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             Toast.makeText(context, "Could not open properties file termux.properties.", Toast.LENGTH_LONG).show();
             Log.e("termux", "Error loading props", e);
         }


### PR DESCRIPTION
Should fix
```
java.lang.IllegalArgumentException: Malformed \uxxxx encoding.
```
?