### PR TITLE
Add an "Autofill password" context menu action

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -38,6 +38,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.view.autofill.AutofillManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
@@ -92,6 +93,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
     private static final int CONTEXTMENU_STYLING_ID = 6;
     private static final int CONTEXTMENU_HELP_ID = 8;
     private static final int CONTEXTMENU_TOGGLE_KEEP_SCREEN_ON = 9;
+    private static final int CONTEXTMENU_AUTOFILL_ID = 10;
 
     private static final int MAX_SESSIONS = 8;
 
@@ -655,6 +657,12 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
 
         menu.add(Menu.NONE, CONTEXTMENU_SELECT_URL_ID, Menu.NONE, R.string.select_url);
         menu.add(Menu.NONE, CONTEXTMENU_SHARE_TRANSCRIPT_ID, Menu.NONE, R.string.select_all_and_share);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            AutofillManager autofillManager = getSystemService(AutofillManager.class);
+            if (autofillManager != null && autofillManager.isEnabled()) {
+                menu.add(Menu.NONE, CONTEXTMENU_AUTOFILL_ID, Menu.NONE, R.string.autofill_password);
+            }
+        }
         menu.add(Menu.NONE, CONTEXTMENU_RESET_TERMINAL_ID, Menu.NONE, R.string.reset_terminal);
         menu.add(Menu.NONE, CONTEXTMENU_KILL_PROCESS_ID, Menu.NONE, getResources().getString(R.string.kill_process, getCurrentTermSession().getPid())).setEnabled(currentSession.isRunning());
         menu.add(Menu.NONE, CONTEXTMENU_STYLING_ID, Menu.NONE, R.string.style_terminal);
@@ -869,6 +877,14 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                     mSettings.setScreenAlwaysOn(this, true);
                 }
                 return true;
+            }
+            case CONTEXTMENU_AUTOFILL_ID: {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    AutofillManager autofillManager = getSystemService(AutofillManager.class);
+                    if (autofillManager != null && autofillManager.isEnabled()) {
+                        autofillManager.requestAutofill(mTerminalView);
+                    }
+                }
             }
             default:
                 return super.onContextItemSelected(item);

--- a/app/src/main/res/layout/drawer_layout.xml
+++ b/app/src/main/res/layout/drawer_layout.xml
@@ -19,7 +19,9 @@
             android:layout_marginLeft="3dp"
             android:focusableInTouchMode="true"
             android:scrollbarThumbVertical="@drawable/terminal_scroll_shape"
-            android:scrollbars="vertical" />
+            android:scrollbars="vertical"
+            android:importantForAutofill="no"
+            android:autofillHints="password" />
 
         <LinearLayout
             android:id="@+id/left_drawer"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="share_transcript_title">Terminal transcript</string>
     <string name="help">Help</string>
     <string name="toggle_keep_screen_on">Keep screen on</string>
+    <string name="autofill_password">Autofill password</string>
 
     <string name="bootstrap_installer_body">Installing…</string>
     <string name="bootstrap_error_title">Unable to install</string>

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -31,11 +31,14 @@ import android.view.ViewParent;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.view.accessibility.AccessibilityManager;
+import android.view.autofill.AutofillValue;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.widget.PopupWindow;
 import android.widget.Scroller;
+
+import androidx.annotation.RequiresApi;
 
 import com.termux.terminal.EmulatorDebug;
 import com.termux.terminal.KeyHandler;
@@ -1511,5 +1514,25 @@ public final class TerminalView extends View {
                     showFloatingToolbar();
             }
         }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @Override
+    public void autofill(AutofillValue value) {
+        if (value.isText()) {
+            mTermSession.write(value.getTextValue().toString());
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @Override
+    public int getAutofillType() {
+        return AUTOFILL_TYPE_TEXT;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @Override
+    public AutofillValue getAutofillValue() {
+        return AutofillValue.forText("");
     }
 }


### PR DESCRIPTION
It would help users if they were able to let their password managers enter passwords into terminal sessions for them. While there are legacy solutions for this that already work with Termus (accessibility services and custom IMEs), as of Android Oreo, the preferred method for this usecase is using the system-provided Autofill API.

This commit adds a context menu action that sends a password field Autofill request to the currently registered Autofill service. Triggering the Autofill UI requires an explicit user action (due to `importantForAutofill="no"`) and the context menu action is only shown when Autofill is both supported and enabled.