### PR TITLE
Bug fixes and improvements for "RUN_COMMAND_ACTION" intent. Issue #1029.

### DIFF
--- a/app/src/main/java/com/termux/app/RunCommandService.java
+++ b/app/src/main/java/com/termux/app/RunCommandService.java
@@ -15,18 +15,32 @@ import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 /**
- * When allow-external-apps property is set to "true", Termux is able to process execute intents
- * sent by third-party applications.
+ * When allow-external-apps property is set to "true" in ~/.termux/termux.properties, Termux 
+ * is able to process execute intents sent by third-party applications.
  *
  * Third-party program must declare com.termux.permission.RUN_COMMAND permission and it should be
  * granted by user.
+ * Full path of command or script must be given in "RUN_COMMAND_PATH" extra.
+ * The "RUN_COMMAND_ARGUMENTS", "RUN_COMMAND_WORKDIR" and "RUN_COMMAND_BACKGROUND" extras are 
+ * optional. The background mode defaults to false.
  *
- * Sample code to run command "top":
+ * Sample code to run command "top" with java:
  *   Intent intent = new Intent();
  *   intent.setClassName("com.termux", "com.termux.app.RunCommandService");
  *   intent.setAction("com.termux.RUN_COMMAND");
  *   intent.putExtra("com.termux.RUN_COMMAND_PATH", "/data/data/com.termux/files/usr/bin/top");
+ *   intent.putExtra("com.termux.RUN_COMMAND_ARGUMENTS", new String[]{"-n", "5"});
+ *   intent.putExtra("com.termux.RUN_COMMAND_WORKDIR", "/data/data/com.termux/files/home");
+ *   intent.putExtra("com.termux.RUN_COMMAND_BACKGROUND", false);
  *   startService(intent);
+ *
+ * Sample code to run command "top" with "am startservice" command:
+ * am startservice --user 0 -n com.termux/com.termux.app.RunCommandService 
+ * -a com.termux.RUN_COMMAND 
+ * --es com.termux.RUN_COMMAND_PATH '/data/data/com.termux/files/usr/bin/top' 
+ * --esa com.termux.RUN_COMMAND_ARGUMENTS '-n,5' 
+ * --es com.termux.RUN_COMMAND_WORKDIR '/data/data/com.termux/files/home'
+ * --ez com.termux.RUN_COMMAND_BACKGROUND 'false'
  */
 public class RunCommandService extends Service {
 
@@ -34,6 +48,7 @@ public class RunCommandService extends Service {
     public static final String RUN_COMMAND_PATH = "com.termux.RUN_COMMAND_PATH";
     public static final String RUN_COMMAND_ARGUMENTS = "com.termux.RUN_COMMAND_ARGUMENTS";
     public static final String RUN_COMMAND_WORKDIR = "com.termux.RUN_COMMAND_WORKDIR";
+    public static final String RUN_COMMAND_BACKGROUND = "com.termux.RUN_COMMAND_BACKGROUND";
 
     class LocalBinder extends Binder {
         public final RunCommandService service = RunCommandService.this;
@@ -52,8 +67,9 @@ public class RunCommandService extends Service {
 
             Intent execIntent = new Intent(TermuxService.ACTION_EXECUTE, programUri);
             execIntent.setClass(this, TermuxService.class);
-            execIntent.putExtra(TermuxService.EXTRA_ARGUMENTS, intent.getStringExtra(RUN_COMMAND_ARGUMENTS));
+            execIntent.putExtra(TermuxService.EXTRA_ARGUMENTS, intent.getStringArrayExtra(RUN_COMMAND_ARGUMENTS));
             execIntent.putExtra(TermuxService.EXTRA_CURRENT_WORKING_DIRECTORY, intent.getStringExtra(RUN_COMMAND_WORKDIR));
+            execIntent.putExtra(TermuxService.EXTRA_EXECUTE_IN_BACKGROUND, intent.getBooleanExtra(RUN_COMMAND_BACKGROUND, false));
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 this.startForegroundService(execIntent);

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -63,7 +63,7 @@ public final class TermuxService extends Service implements SessionChangedCallba
     public static final String EXTRA_ARGUMENTS = "com.termux.execute.arguments";
 
     public static final String EXTRA_CURRENT_WORKING_DIRECTORY = "com.termux.execute.cwd";
-    private static final String EXTRA_EXECUTE_IN_BACKGROUND = "com.termux.execute.background";
+    public static final String EXTRA_EXECUTE_IN_BACKGROUND = "com.termux.execute.background";
 
     /** This service is only bound from inside the same process and never uses IPC. */
     class LocalBinder extends Binder {


### PR DESCRIPTION
Fixes `RUN_COMMAND_ARGUMENTS` extra for `RUN_COMMAND_ACTION` intent. Check [here](https://github.com/termux/termux-app/pull/1029#issuecomment-666481152) for details.

Adds `RUN_COMMAND_BACKGROUND` extra for `RUN_COMMAND_ACTION` intent to run termux session in background. Check [here](https://github.com/termux/termux-app/pull/1029#issuecomment-649715644) for details.

Hopefully, this should fix the issues. I haven't tested the code but seems fine on overview since minimal changes are made in java code. Let me know if I should test as well.