### PR TITLE
Fix RunCommandService crash and foreground issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <application
         android:extractNativeLibs="true"

--- a/app/src/main/java/com/termux/app/RunCommandService.java
+++ b/app/src/main/java/com/termux/app/RunCommandService.java
@@ -87,6 +87,7 @@ public class RunCommandService extends Service {
         runStartForeground();
     }
 
+    @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         // Run again in case service is already started and onCreate() is not called
         runStartForeground();

--- a/app/src/main/java/com/termux/app/RunCommandService.java
+++ b/app/src/main/java/com/termux/app/RunCommandService.java
@@ -26,9 +26,21 @@ import java.util.Properties;
  *
  * Third-party program must declare com.termux.permission.RUN_COMMAND permission and it should be
  * granted by user.
- * Full path of command or script must be given in "RUN_COMMAND_PATH" extra.
+ *
+ * Absolute path of command or script must be given in "RUN_COMMAND_PATH" extra.
  * The "RUN_COMMAND_ARGUMENTS", "RUN_COMMAND_WORKDIR" and "RUN_COMMAND_BACKGROUND" extras are 
- * optional. The background mode defaults to false.
+ * optional. The workdir defaults to termux home. The background mode defaults to "false".
+ * The command path and workdir can optionally be prefixed with "$PREFIX/" or "~/" if an absolute
+ * path is not to be given.
+ *
+ * To automatically bring to foreground and start termux commands that were started with
+ * background mode "false" in android >= 10 without user having to click the notification manually,
+ * requires termux to be granted draw over apps permission due to new restrictions
+ * of starting activities from the background, this also applies to Termux:Tasker plugin.
+ *
+ * To reduce the chance of termux being killed by android even further due to violation of not
+ * being able to call startForeground() within ~5s of service start in android >= 8, the user
+ * may disable battery optimizations for termux.
  *
  * Sample code to run command "top" with java:
  *   Intent intent = new Intent();

--- a/app/src/main/java/com/termux/app/RunCommandService.java
+++ b/app/src/main/java/com/termux/app/RunCommandService.java
@@ -80,12 +80,12 @@ public class RunCommandService extends Service {
         runStartForeground();
 
         if (allowExternalApps() && RUN_COMMAND_ACTION.equals(intent.getAction())) {
-            Uri programUri = new Uri.Builder().scheme("com.termux.file").path(intent.getStringExtra(RUN_COMMAND_PATH)).build();
+            Uri programUri = new Uri.Builder().scheme("com.termux.file").path(parsePath(intent.getStringExtra(RUN_COMMAND_PATH))).build();
 
             Intent execIntent = new Intent(TermuxService.ACTION_EXECUTE, programUri);
             execIntent.setClass(this, TermuxService.class);
             execIntent.putExtra(TermuxService.EXTRA_ARGUMENTS, intent.getStringArrayExtra(RUN_COMMAND_ARGUMENTS));
-            execIntent.putExtra(TermuxService.EXTRA_CURRENT_WORKING_DIRECTORY, intent.getStringExtra(RUN_COMMAND_WORKDIR));
+            execIntent.putExtra(TermuxService.EXTRA_CURRENT_WORKING_DIRECTORY, parsePath(intent.getStringExtra(RUN_COMMAND_WORKDIR)));
             execIntent.putExtra(TermuxService.EXTRA_EXECUTE_IN_BACKGROUND, intent.getBooleanExtra(RUN_COMMAND_BACKGROUND, false));
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -162,5 +162,15 @@ public class RunCommandService extends Service {
         }
 
         return props.getProperty("allow-external-apps", "false").equals("true");
+    }
+
+    /** Replace "$PREFIX/" or "~/" prefix with termux absolute paths */
+    private String parsePath(String path) {
+        if(path != null && !path.isEmpty()) {
+            path = path.replaceAll("^\\$PREFIX\\/", TermuxService.PREFIX_PATH + "/");
+            path = path.replaceAll("^~\\/", TermuxService.HOME_PATH + "/");
+        }
+
+        return path;
     }
 }


### PR DESCRIPTION
Since `startForeground()` function is not being called, occasionally termux is killed by android with the following exception

```
I/ActivityTaskManager: START u0 {flg=0x10000000 cmp=com.termux/.app.TermuxActivity} from uid 10138
W/ActivityTaskManager: Background activity start [callingPackage: com.termux; callingUid: 10138; isCallingUidForeground: false; isCallingUidPersistentSystemProcess: false; realCallingUid: 10138; isRealCallingUidForeground: false; isRealCallingUidPersistentSystemProcess: false; originatingPendingIntent: null; isBgStartWhitelisted: false; intent: Intent { flg=0x10000000 cmp=com.termux/.app.TermuxActivity }; callerApp: ProcessRecord{75609ea 14280:com.termux/u0a138}]
D/AndroidRuntime: Shutting down VM
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.termux, PID: 14280
    android.app.RemoteServiceException: Context.startForegroundService() did not then call Service.startForeground(): ServiceRecord{f94f200 u0 com.termux/.app.RunCommandService}
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1945)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
I/ActivityManager: Showing crash dialog for package com.termux u0
W/ActivityManager: Bringing down service while still waiting for start foreground: ServiceRecord{d0f1bbf u0 com.termux/.app.RunCommandService}
I/ActivityManager: Crashing app skipping ANR: ProcessRecord{75609ea 14280:com.termux/u0a138} Context.startForegroundService() did not then call Service.startForeground(): ServiceRecord{d0f1bbf u0 com.termux/.app.RunCommandService}
```  
I have added calls to  `startForeground()` in both `onCreate()` and `onStartCommand()` and have tested the in android 10 emulator and the fix seems to be working with no crashes yet. I even tested under low free RAM conditions in order to slow down the phone but termux still didn't crash. Of course, it could potentially still crash because the function may not be called in under `5s` in all circumstances since its a framework issue. More details [here](https://stackoverflow.com/questions/44425584/context-startforegroundservice-did-not-then-call-service-startforeground/53402038). Disabling battery optimization is likely the better way but this also works and is the recommended way.

Adding `android.permission.SYSTEM_ALERT_WINDOW` permission to fix the foreground issue seems to be the reasonable way to go since all the other [exceptions](https://developer.android.com/guide/components/activities/background-starts#exceptions) to the rule do not really apply to termux, and without it, it greatly reduces usability of both the `RUN_COMMAND` intents and `Termux:Tasker` plugin. If a user has already set a certain command to be run in a foreground session from a background task like from tasker, it should run in foreground without user intervention. The hack that currently works for running termux commands from tasker is to do a `sleep 1; am start --user 0 -n com.termux/com.termux.app.TermuxActivity` after running the `Termux:Tasker` plugin or TermuxCommand action, since tasker already has requested  `android.permission.SYSTEM_ALERT_WINDOW` permission and also has an accessibility service, so it can actually start termux activity from its own background execution service, but termux itself can't from its own service. I haven't currently added a way for the user to request the permission from within termux, let me know if that is even required.

Let me know if there are any other issues. Thanks

 