### PR TITLE
Don't exclude hidden files from document provider (#1220)

### DIFF
--- a/app/src/main/java/com/termux/filepicker/TermuxDocumentsProvider.java
+++ b/app/src/main/java/com/termux/filepicker/TermuxDocumentsProvider.java
@@ -91,9 +91,7 @@ public class TermuxDocumentsProvider extends DocumentsProvider {
         final MatrixCursor result = new MatrixCursor(projection != null ? projection : DEFAULT_DOCUMENT_PROJECTION);
         final File parent = getFileForDocId(parentDocumentId);
         for (File file : parent.listFiles()) {
-            if (!file.getName().startsWith(".")) {
-                includeFile(result, null, file);
-            }
+            includeFile(result, null, file);
         }
         return result;
     }
@@ -177,8 +175,7 @@ public class TermuxDocumentsProvider extends DocumentsProvider {
             } catch (IOException e) {
                 isInsideHome = true;
             }
-            final boolean isHidden = file.getName().startsWith(".");
-            if (isInsideHome && !isHidden) {
+            if (isInsideHome) {
                 if (file.isDirectory()) {
                     Collections.addAll(pending, file.listFiles());
                 } else {


### PR DESCRIPTION
Credit to @johnmellor for requesting the document provider in the
first place via #79, mentioning this limitation in a comment on
that issue, and creating a commit like this one to address it.