### PR TITLE
Add workaround property to fix ctrl+space on devices where this does not work

### DIFF
--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -539,6 +539,8 @@ public final class TerminalView extends View {
 
     @Override
     public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        Properties props = getProperties();
+
         if (LOG_KEY_EVENTS)
             Log.i(EmulatorDebug.LOG_TAG, "onKeyPreIme(keyCode=" + keyCode + ", event=" + event + ")");
         if (keyCode == KeyEvent.KEYCODE_BACK) {
@@ -554,6 +556,11 @@ public final class TerminalView extends View {
                         return onKeyUp(keyCode, event);
                 }
             }
+        } else if (props.getProperty("ctrl-space-workaround", "false").equals("true") &&
+                   keyCode == KeyEvent.KEYCODE_SPACE && event.isCtrlPressed()) {
+            /* ctrl + space does not work on some ROMs without this workaround.
+               However, this breaks it on devices where it works out of the box. */
+            return onKeyDown(keyCode, event);
         }
         return super.onKeyPreIme(keyCode, event);
     }

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -255,20 +255,7 @@ public final class TerminalView extends View {
 
     @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-        File propsFile = new File(getContext().getFilesDir() + "/home/.termux/termux.properties");
-        if (!propsFile.exists())
-            propsFile = new File(getContext().getFilesDir() + "/home/.config/termux/termux.properties");
-
-        Properties props = new Properties();
-        try {
-            if (propsFile.isFile() && propsFile.canRead()) {
-                try (FileInputStream in = new FileInputStream(propsFile)) {
-                    props.load(new InputStreamReader(in, StandardCharsets.UTF_8));
-                }
-            }
-        } catch (Exception e) {
-            Log.e("termux", "Error loading props", e);
-        }
+        Properties props = getProperties();
 
         if (props.getProperty("enforce-char-based-input", "false").equals("true")) {
             // Some keyboards seems do not reset the internal state on TYPE_NULL.
@@ -1542,6 +1529,34 @@ public final class TerminalView extends View {
                     showFloatingToolbar();
             }
         }
+    }
+
+    private Properties getProperties() {
+        File propsFile;
+        Properties props = new Properties();
+        String possiblePropLocations[] = {
+            getContext().getFilesDir() + "/home/.termux/termux.properties",
+            getContext().getFilesDir() + "/home/.config/termux/termux.properties"
+        };
+
+        propsFile = new File(possiblePropLocations[0]);
+        int i = 1;
+        while (!propsFile.exists() && i <= possiblePropLocations.length) {
+            propsFile = new File(possiblePropLocations[i]);
+            i += 1;
+        }
+
+        try {
+            if (propsFile.isFile() && propsFile.canRead()) {
+                try (FileInputStream in = new FileInputStream(propsFile)) {
+                    props.load(new InputStreamReader(in, StandardCharsets.UTF_8));
+                }
+            }
+        } catch (Exception e) {
+            Log.e("termux", "Error loading props", e);
+        }
+
+        return props;
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)


### PR DESCRIPTION
Should fix (or well, allow user to set a property and thereby fix) https://github.com/termux/termux-app/issues/1333. 

This is a problem in for example emacs when a user uses a hardware keyboard and wants to mark text by pressing ctrl+space. On some devices pressing ctrl + space currently does nothing, but with PR users that want this functionality can add `ctrl-space-workaround=true` to `~/.termux/termux.properties` and then run `termux-reload-settings` to make ctrl+space work as expected. 

Confirmed to work on my phone.