### PR TITLE
app: enable split apk builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,9 +25,14 @@ android {
                 cFlags "-std=c11", "-Wall", "-Wextra", "-Werror", "-Os", "-fno-stack-protector", "-Wl,--gc-sections"
             }
         }
+    }
 
-        ndk {
-            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
+    splits {
+        abi {
+            enable true
+
+            reset ()
+            include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
         }
 
     }


### PR DESCRIPTION
Currently we build a single APK which handles the four supported ABIs.

Therefore each user, downloads 50-75% more than they need - adding
towards both client/server-side network as well as device storage.

Use a split APK approach - it costs nothing from build and server-side
storage POV.

Note: We're removing ndk:abiFilters - they're incompatible/superseded by
the splits:abi:include list.

Signed-off-by: Emil Velikov <emil.l.velikov@gmail.com>