### PR TITLE
Fix/Allow fullscreen mode to consume status bar area on some devices

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -222,11 +222,17 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
         View content = findViewById(android.R.id.content);
         content.setOnApplyWindowInsetsListener((v, insets) -> {
             mNavBarHeight = insets.getSystemWindowInsetBottom();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                return insets.replaceSystemWindowInsets(0, 0, 0, mNavBarHeight);
+            }
             return insets;
         });
 
         if (mSettings.isUsingFullScreen()) {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                getWindow().getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+            }
         }
 
         if (mIsUsingBlackUI) {


### PR DESCRIPTION
![Screen Shot 2021-02-07 at 6 05 39 PM](https://user-images.githubusercontent.com/6166095/107163437-19332280-696f-11eb-8aa0-592e2fccc07e.png)

This PR fixes the blank black bar that would display in fullscreen mode on some devices such as Pixel 4. 
@xeffyr Do you think we should make this another config option for users? On one hand, you get to utilize the extra vertical screen real estate, BUT 1-2 characters on left/right side can get cut off at the very top. Some might prefer one over the other?