### PR TITLE
Make Termux debuggable to allow ADB 'run-as'

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         android:banner="@drawable/banner"
         android:label="@string/application_name"
         android:theme="@style/Theme.Termux"
+        android:debuggable="true"
         android:supportsRtl="false" >
 
         <!-- This (or rather, value 2.1 or higher) is needed to make the Samsung Galaxy S8


### PR DESCRIPTION
This resolves #924 and makes it possible to access Termux directrly from `adb shell` via `run-as`.

Not totally elegant, but it works:
```
% adb shell
dreamlte:/ $ run-as com.termux
dreamlte:/data/data/com.termux $ PATH=/data/data/com.termux/files/usr/bin LD_PRELOAD=/data/data/com.termux/files/usr/lib/libtermux-exec.so /data/data/com.termux/files/usr/bin/bash -l
~ $ python
Python 3.9.2 (default, Feb 22 2021, 12:26:04)
[Clang 9.0.8 (https://android.googlesource.com/toolchain/llvm-project 98c855489 on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
```