### PR TITLE
Fix issue where soft keyboard would not show in some cases

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -130,6 +130,11 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
     private boolean mIsVisible;
 
     /**
+     * If onResume() was called after onCreate().
+     */
+    private boolean isOnResumeAfterOnCreate = false;
+
+    /**
      * The {@link TermuxActivity} is in an invalid state and must not be run.
      */
     private boolean mIsInvalidState;
@@ -160,6 +165,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
     public void onCreate(Bundle savedInstanceState) {
 
         Logger.logDebug(LOG_TAG, "onCreate");
+        isOnResumeAfterOnCreate = true;
 
         // Check if a crash happened on last run of the app and show a
         // notification with the crash details if it did
@@ -251,6 +257,8 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
 
         if (mTermuxTerminalViewClient != null)
             mTermuxTerminalViewClient.onResume();
+
+        isOnResumeAfterOnCreate = false;
     }
 
     @Override
@@ -689,6 +697,10 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
 
     public boolean isVisible() {
         return mIsVisible;
+    }
+
+    public boolean isOnResumeAfterOnCreate() {
+        return isOnResumeAfterOnCreate;
     }
 
 


### PR DESCRIPTION
1. If `soft-keyboard-toggle-behaviour=enable/disable` was set, then pressing keyboard toggle wouldn't show the keyboard after switching back from another app if keyboard was previously disabled by user.
2. If switching back from another app, like when opening url with context menu "Select URL" long press and returning to termux with back button, then soft keyboard wouldn't automatically open like it does on app startup.

Fixes #2111, Fixes #2112

@trygveaa Here it is, kindly test. Thanks.