### PR TITLE
Support clicking directly on a URL to open it

### DIFF
--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
@@ -36,6 +36,7 @@ import com.termux.shared.markdown.MarkdownUtils;
 import com.termux.shared.termux.TermuxUtils;
 import com.termux.shared.view.KeyboardUtils;
 import com.termux.terminal.KeyHandler;
+import com.termux.terminal.TerminalBuffer;
 import com.termux.terminal.TerminalEmulator;
 import com.termux.terminal.TerminalSession;
 
@@ -152,10 +153,19 @@ public class TermuxTerminalViewClient extends TermuxTerminalViewClientBase {
 
     @Override
     public void onSingleTapUp(MotionEvent e) {
-        if (!KeyboardUtils.areDisableSoftKeyboardFlagsSet(mActivity))
-            KeyboardUtils.showSoftKeyboard(mActivity, mActivity.getTerminalView());
-        else
-            Logger.logVerbose(LOG_TAG, "Not showing soft keyboard onSingleTapUp since its disabled");
+        TerminalEmulator term = mActivity.getCurrentSession().getEmulator();
+        int[] xAndY = mActivity.getTerminalView().getTextSelectionCursorController().getXAndYFromEvent(e);
+        String wordAtTap = term.getScreen().getWordAtLocation(xAndY[0], xAndY[1]);
+        LinkedHashSet<CharSequence> urlSet = DataUtils.extractUrls(wordAtTap);
+        if (!urlSet.isEmpty()) {
+            String url = (String) urlSet.iterator().next();
+            openUrl(url);
+        } else if (!term.isMouseTrackingActive() && !e.isFromSource(InputDevice.SOURCE_MOUSE)) {
+            if (!KeyboardUtils.areDisableSoftKeyboardFlagsSet(mActivity))
+                KeyboardUtils.showSoftKeyboard(mActivity, mActivity.getTerminalView());
+            else
+                Logger.logVerbose(LOG_TAG, "Not showing soft keyboard onSingleTapUp since its disabled");
+        }
     }
 
     @Override
@@ -608,18 +618,22 @@ public class TermuxTerminalViewClient extends TermuxTerminalViewClientBase {
             lv.setOnItemLongClickListener((parent, view, position, id) -> {
                 dialog.dismiss();
                 String url = (String) urls[position];
-                Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                try {
-                    mActivity.startActivity(i, null);
-                } catch (ActivityNotFoundException e) {
-                    // If no applications match, Android displays a system message.
-                    mActivity.startActivity(Intent.createChooser(i, null));
-                }
+                openUrl(url);
                 return true;
             });
         });
 
         dialog.show();
+    }
+
+    public void openUrl(String url) {
+        Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        try {
+            mActivity.startActivity(i, null);
+        } catch (ActivityNotFoundException e) {
+            // If no applications match, Android displays a system message.
+            mActivity.startActivity(Intent.createChooser(i, null));
+        }
     }
 
     public void reportIssueFromTranscript() {

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -102,6 +102,28 @@ public final class TerminalBuffer {
         return builder.toString();
     }
 
+    public String getWordAtLocation(int x, int y) {
+        int y1 = y;
+        int y2 = y;
+        while (y1 > 0 && !getSelectedText(0, y1 - 1, mColumns, y2, true, true).contains("\n")) {
+            y1--;
+        }
+        while (y2 < mScreenRows && !getSelectedText(0, y1, mColumns, y2 + 1, true, true).contains("\n")) {
+            y2++;
+        }
+        String text = getSelectedText(0, y1, mColumns, y2, true, true);
+        int textOffset = (y - y1) * mColumns + x;
+        int x1 = text.lastIndexOf(' ', textOffset);
+        if (x1 == -1) {
+            x1 = 0;
+        }
+        int x2 = text.indexOf(' ', textOffset);
+        if (x2 == -1) {
+            x2 = text.length();
+        }
+        return text.substring(x1, x2);
+    }
+
     public int getActiveTranscriptRows() {
         return mActiveTranscriptRows;
     }

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -94,7 +94,7 @@ public final class TerminalView extends View {
             @Override
             public boolean onUp(MotionEvent event) {
                 mScrollRemainder = 0.0f;
-                if (mEmulator != null && mEmulator.isMouseTrackingActive() && !isSelectingText() && !scrolledWithFinger) {
+                if (mEmulator != null && mEmulator.isMouseTrackingActive() && !event.isFromSource(InputDevice.SOURCE_MOUSE) && !isSelectingText() && !scrolledWithFinger) {
                     // Quick event processing when mouse tracking is active - do not wait for check of double tapping
                     // for zooming.
                     sendMouseEventCode(event, TerminalEmulator.MOUSE_LEFT_BUTTON, true);
@@ -114,13 +114,8 @@ public final class TerminalView extends View {
                     return true;
                 }
                 requestFocus();
-                if (!mEmulator.isMouseTrackingActive()) {
-                    if (!event.isFromSource(InputDevice.SOURCE_MOUSE)) {
-                        mClient.onSingleTapUp(event);
-                        return true;
-                    }
-                }
-                return false;
+                mClient.onSingleTapUp(event);
+                return true;
             }
 
             @Override
@@ -533,7 +528,6 @@ public final class TerminalView extends View {
                         sendMouseEventCode(event, TerminalEmulator.MOUSE_LEFT_BUTTON_MOVED, true);
                         break;
                 }
-                return true;
             }
         }
 
@@ -995,7 +989,7 @@ public final class TerminalView extends View {
     /**
      * Define functions required for text selection and its handles.
      */
-    TextSelectionCursorController getTextSelectionCursorController() {
+    public TextSelectionCursorController getTextSelectionCursorController() {
         if (mTextSelectionCursorController == null) {
             mTextSelectionCursorController = new TextSelectionCursorController(this);
 

--- a/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionCursorController.java
+++ b/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionCursorController.java
@@ -88,15 +88,19 @@ public class TextSelectionCursorController implements CursorController {
         }
     }
 
-    public void setInitialTextSelectionPosition(MotionEvent event) {
+    public int[] getXAndYFromEvent(MotionEvent event) {
         int cx = (int) (event.getX() / terminalView.mRenderer.getFontWidth());
         final boolean eventFromMouse = event.isFromSource(InputDevice.SOURCE_MOUSE);
         // Offset for finger:
         final int SELECT_TEXT_OFFSET_Y = eventFromMouse ? 0 : -40;
         int cy = (int) ((event.getY() + SELECT_TEXT_OFFSET_Y) / terminalView.mRenderer.getFontLineSpacing()) + terminalView.getTopRow();
+        return new int[] { cx, cy };
+    }
 
-        mSelX1 = mSelX2 = cx;
-        mSelY1 = mSelY2 = cy;
+    public void setInitialTextSelectionPosition(MotionEvent event) {
+        int[] xAndY = getXAndYFromEvent(event);
+        mSelX1 = mSelX2 = xAndY[0];
+        mSelY1 = mSelY2 = xAndY[1];
 
         TerminalBuffer screen = terminalView.mEmulator.getScreen();
         if (!" ".equals(screen.getSelectedText(mSelX1, mSelY1, mSelX1, mSelY1))) {


### PR DESCRIPTION
This allows you to click/press directly on a URL in the terminal view to
open it. It takes priority over opening the keyboard, so if you click on
a URL it is opened, and if you click anywhere else the keyboard opens
like before.

Currently, if the application in the terminal is tracking the mouse and
you click on a URL, both actions happen. The mouse event is sent to the
application, and the URL is also opened.