### PR TITLE
terminal: invert text color under block cursor

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
@@ -57,7 +57,7 @@ public final class TerminalColorScheme {
         0xff808080, 0xff8a8a8a, 0xff949494, 0xff9e9e9e, 0xffa8a8a8, 0xffb2b2b2, 0xffbcbcbc, 0xffc6c6c6, 0xffd0d0d0, 0xffdadada, 0xffe4e4e4, 0xffeeeeee,
 
         // COLOR_INDEX_DEFAULT_FOREGROUND, COLOR_INDEX_DEFAULT_BACKGROUND and COLOR_INDEX_DEFAULT_CURSOR:
-        0xffffffff, 0xff000000, 0xffA9AAA9};
+        0xffffffff, 0xff000000, 0xffffffff};
 
     public final int[] mDefaultColors = new int[TextStyle.NUM_INDEXED_COLORS];
 

--- a/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
@@ -118,9 +118,13 @@ public final class TerminalRenderer {
                         final int columnWidthSinceLastRun = column - lastRunStartColumn;
                         final int charsSinceLastRun = currentCharIndex - lastRunStartIndex;
                         int cursorColor = lastRunInsideCursor ? mEmulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_CURSOR] : 0;
+                        boolean invertCursorTextColor = false;
+                        if (lastRunInsideCursor && cursorShape == TerminalEmulator.TERMINAL_CURSOR_STYLE_BLOCK) {
+                            invertCursorTextColor = true;
+                        }
                         drawTextRun(canvas, line, palette, heightOffset, lastRunStartColumn, columnWidthSinceLastRun,
                             lastRunStartIndex, charsSinceLastRun, measuredWidthForRun,
-                            cursorColor, cursorShape, lastRunStyle, reverseVideo || lastRunInsideSelection);
+                            cursorColor, cursorShape, lastRunStyle, reverseVideo || invertCursorTextColor || lastRunInsideSelection);
                     }
                     measuredWidthForRun = 0.f;
                     lastRunStyle = style;
@@ -143,8 +147,12 @@ public final class TerminalRenderer {
             final int columnWidthSinceLastRun = columns - lastRunStartColumn;
             final int charsSinceLastRun = currentCharIndex - lastRunStartIndex;
             int cursorColor = lastRunInsideCursor ? mEmulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_CURSOR] : 0;
+            boolean invertCursorTextColor = false;
+            if (lastRunInsideCursor && cursorShape == TerminalEmulator.TERMINAL_CURSOR_STYLE_BLOCK) {
+                invertCursorTextColor = true;
+            }
             drawTextRun(canvas, line, palette, heightOffset, lastRunStartColumn, columnWidthSinceLastRun, lastRunStartIndex, charsSinceLastRun,
-                measuredWidthForRun, cursorColor, cursorShape, lastRunStyle, reverseVideo || lastRunInsideSelection);
+                measuredWidthForRun, cursorColor, cursorShape, lastRunStyle, reverseVideo || invertCursorTextColor || lastRunInsideSelection);
         }
     }
 


### PR DESCRIPTION
Issue: https://github.com/termux/termux-app/issues/219

Before
![before](https://user-images.githubusercontent.com/25881154/130078170-ed5479fa-339b-4fe1-863f-2d626f290f21.png)

After
![after](https://user-images.githubusercontent.com/25881154/130078198-d08858d0-b6ce-4e51-b110-e87e73bcfb8a.png)

***

Another commit changes default cursor color to white, which in my opinion is better suitable for default color scheme.

![whiteblock](https://user-images.githubusercontent.com/25881154/130080291-1752fd8b-2b23-47ae-9be6-c2d492d82352.png)

![whitebar](https://user-images.githubusercontent.com/25881154/130080266-c7b00c41-6369-4674-b523-151134e55fb9.png)

When using bar cursor style, it has worse visibility if colored in grey:
![oldbar](https://user-images.githubusercontent.com/25881154/130081010-d142da59-1033-4736-b1e6-1747cb087395.png)
