### PR TITLE
termux-shared: add android.permission.VIBRATE to manifest

### DIFF
--- a/termux-shared/src/main/AndroidManifest.xml
+++ b/termux-shared/src/main/AndroidManifest.xml
@@ -1,3 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.termux.shared">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.termux.shared">
+    <uses-permission android:name="android.permission.VIBRATE" />
 </manifest>


### PR DESCRIPTION
./gradlew lint complains about vibrations being used in termux-shared/src/main/java/com/termux/shared/terminal/io/BellHandler.java without the permission being declared:

```
/home/grimler/projects/termux/termux-app/termux-shared/src/main/java/com/termux/shared/terminal/io/BellHandler.java:45: Error: Missing permissions required by Vibrator.vibrate: android.permission.VIBRATE [MissingPermission]
                              vibrator.vibrate(VibrationEffect.createOneShot(DURATION, VibrationEffect.DEFAULT_AMPLITUDE));
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/grimler/projects/termux/termux-app/termux-shared/src/main/java/com/termux/shared/terminal/io/BellHandler.java:47: Error: Missing permissions required by Vibrator.vibrate: android.permission.VIBRATE [MissingPermission]
                              vibrator.vibrate(DURATION);
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~
```