### PR TITLE
TermuxFileReceiverActivity is using wrong path for "usr/bin/"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -127,18 +127,6 @@
                 <data android:mimeType="text/*" />
                 <data android:mimeType="video/*" />
             </intent-filter>
-            <!-- Accept multiple file types to let Termux be usable as generic file viewer. -->
-            <intent-filter tools:ignore="AppLinkUrlError">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-
-                <data android:mimeType="application/*" />
-                <data android:mimeType="audio/*" />
-                <data android:mimeType="image/*" />
-                <data android:mimeType="text/*" />
-                <data android:mimeType="video/*" />
-            </intent-filter>
         </activity>
 
 

--- a/app/src/main/java/com/termux/filepicker/TermuxFileReceiverActivity.java
+++ b/app/src/main/java/com/termux/filepicker/TermuxFileReceiverActivity.java
@@ -33,9 +33,9 @@ import java.util.regex.Pattern;
 
 public class TermuxFileReceiverActivity extends AppCompatActivity {
 
-    static final String TERMUX_RECEIVEDIR = TermuxConstants.TERMUX_FILES_DIR_PATH + "/home/downloads";
-    static final String EDITOR_PROGRAM = TermuxConstants.TERMUX_HOME_DIR_PATH + "/bin/termux-file-editor";
-    static final String URL_OPENER_PROGRAM = TermuxConstants.TERMUX_HOME_DIR_PATH + "/bin/termux-url-opener";
+    static final String TERMUX_RECEIVEDIR = TermuxConstants.TERMUX_HOME_DIR_PATH + "/downloads";
+    static final String EDITOR_PROGRAM = TermuxConstants.TERMUX_BIN_PREFIX_DIR_PATH + "/termux-file-editor";
+    static final String URL_OPENER_PROGRAM = TermuxConstants.TERMUX_BIN_PREFIX_DIR_PATH + "/termux-url-opener";
 
     /**
      * If the activity should be finished when the name input dialog is dismissed. This is disabled
@@ -160,7 +160,7 @@ public class TermuxFileReceiverActivity extends AppCompatActivity {
 
                 final File editorProgramFile = new File(EDITOR_PROGRAM);
                 if (!editorProgramFile.isFile()) {
-                    showErrorDialogAndQuit("The following file does not exist:\n$HOME/bin/termux-file-editor\n\n"
+                    showErrorDialogAndQuit("The following file does not exist:\n$PREFIX/bin/termux-file-editor\n\n"
                         + "Create this file as a script or a symlink - it will be called with the received file as only argument.");
                     return;
                 }
@@ -224,7 +224,7 @@ public class TermuxFileReceiverActivity extends AppCompatActivity {
     void handleUrlAndFinish(final String url) {
         final File urlOpenerProgramFile = new File(URL_OPENER_PROGRAM);
         if (!urlOpenerProgramFile.isFile()) {
-            showErrorDialogAndQuit("The following file does not exist:\n$HOME/bin/termux-url-opener\n\n"
+            showErrorDialogAndQuit("The following file does not exist:\n$PREFIX/bin/termux-url-opener\n\n"
                 + "Create this file as a script or a symlink - it will be called with the shared URL as the first argument.");
             return;
         }


### PR DESCRIPTION
I also removed `android.intent.action.VIEW` because it's useless and annoying.
Everytime I open a file of new type, "Open with Termux" shows up, even APK.
We already have `android.intent.action.SEND` so I remove it.