### PR TITLE
Add blinking support for 'cursor style' CSI

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -842,14 +842,17 @@ public final class TerminalEmulator {
                                     case 1: // Blinking block.
                                     case 2: // Steady block.
                                         mCursorStyle = TERMINAL_CURSOR_STYLE_BLOCK;
+                                        setCursorBlinkingEnabled(arg != 2);
                                         break;
                                     case 3: // Blinking underline.
                                     case 4: // Steady underline.
                                         mCursorStyle = TERMINAL_CURSOR_STYLE_UNDERLINE;
+                                        setCursorBlinkingEnabled(arg != 4);
                                         break;
                                     case 5: // Blinking bar (xterm addition).
                                     case 6: // Steady bar (xterm addition).
                                         mCursorStyle = TERMINAL_CURSOR_STYLE_BAR;
+                                        setCursorBlinkingEnabled(arg != 6);
                                         break;
                                 }
                                 break;


### PR DESCRIPTION
Now `echo -e '\e[1 q'` will set blinking cursor and `echo -e '\e[2 q'` will set steady cursor

Warning: Need to enable cursor blinking via `terminal-cursor-blink-rate` in `~/.termux/termux.properties` or else blinking won't work, cursor will always be steady