### PR TITLE
Refactor and apply exception handling in `TerminalColor.java`

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
@@ -74,30 +74,40 @@ public final class TerminalColorScheme {
         for (Map.Entry<Object, Object> entries : props.entrySet()) {
             String key = (String) entries.getKey();
             String value = (String) entries.getValue();
-            int colorIndex;
-
-            if (key.equals("foreground")) {
-                colorIndex = TextStyle.COLOR_INDEX_FOREGROUND;
-            } else if (key.equals("background")) {
-                colorIndex = TextStyle.COLOR_INDEX_BACKGROUND;
-            } else if (key.equals("cursor")) {
-                colorIndex = TextStyle.COLOR_INDEX_CURSOR;
-            } else if (key.startsWith("color")) {
-                try {
-                    colorIndex = Integer.parseInt(key.substring(5));
-                } catch (NumberFormatException e) {
-                    throw new IllegalArgumentException("Invalid property: '" + key + "'");
-                }
-            } else {
-                throw new IllegalArgumentException("Invalid property: '" + key + "'");
-            }
 
             try {
-                int colorValue = TerminalColors.parse(value);
-                mDefaultColors[colorIndex] = colorValue;
+                int colorIndex = getColorIndex(key);
+                setColorAtIndex(value, colorIndex);
             } catch (IllegalArgumentException e) {
                 // Ignore.
             }
+        }
+    }
+
+    private int getColorIndex(String key) {
+        if (key.equals("foreground")) {
+            return TextStyle.COLOR_INDEX_FOREGROUND;
+        } else if (key.equals("background")) {
+            return TextStyle.COLOR_INDEX_BACKGROUND;
+        } else if (key.equals("cursor")) {
+            return TextStyle.COLOR_INDEX_CURSOR;
+        } else if (key.startsWith("color")) {
+            try {
+                return Integer.parseInt(key.substring(5));
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid property: '" + key + "'");
+            }
+        } else {
+            throw new IllegalArgumentException("Invalid property: '" + key + "'");
+        }
+    }
+
+    private void setColorAtIndex(String value, int colorIndex) {
+        try {
+            int colorValue = TerminalColors.parse(value);
+            mDefaultColors[colorIndex] = colorValue;
+        } catch (IllegalArgumentException e) {
+            // Ignore.
         }
     }
 

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
@@ -92,9 +92,12 @@ public final class TerminalColorScheme {
                 throw new IllegalArgumentException("Invalid property: '" + key + "'");
             }
 
-            int colorValue = TerminalColors.parse(value);
-
-            mDefaultColors[colorIndex] = colorValue;
+            try {
+                int colorValue = TerminalColors.parse(value);
+                mDefaultColors[colorIndex] = colorValue;
+            } catch (IllegalArgumentException e) {
+                // Ignore.
+            }
         }
     }
 

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
@@ -93,8 +93,6 @@ public final class TerminalColorScheme {
             }
 
             int colorValue = TerminalColors.parse(value);
-            if (colorValue == 0)
-                throw new IllegalArgumentException("Property '" + key + "' has invalid color: '" + value + "'");
 
             mDefaultColors[colorIndex] = colorValue;
         }

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColors.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColors.java
@@ -33,26 +33,34 @@ public final class TerminalColors {
      * Highest bit is set if successful, so return value is 0xFF${R}${G}${B}. Return 0 if failed.
      */
     static int parse(String colorString) {
-        try {
-            int skipInitial, skipBetween;
-            if (colorString.charAt(0) == '#') {
-                // #RGB, #RRGGBB, #RRRGGGBBB or #RRRRGGGGBBBB. Most significant bits.
-                skipInitial = 1;
-                skipBetween = 0;
-            } else if (colorString.startsWith("rgb:")) {
-                // rgb:<red>/<green>/<blue> where <red>, <green>, <blue> := h | hh | hhh | hhhh. Scaled.
-                skipInitial = 4;
-                skipBetween = 1;
-            } else {
-                throw new IllegalArgumentException("Wrong Prefix Format: '" + colorString + "'");
-            }
-            int charsForColors = colorString.length() - skipInitial - 2 * skipBetween;
-            if (charsForColors % 3 != 0) {
-                throw new IllegalArgumentException("Unequal Length: '" + colorString + "'");
-            }
-            int componentLength = charsForColors / 3;
-            double mult = 255 / (Math.pow(2, componentLength * 4) - 1);
+        int skipInitial, skipBetween;
+        if (colorString.charAt(0) == '#') {
+            // #RGB, #RRGGBB, #RRRGGGBBB or #RRRRGGGGBBBB. Most significant bits.
+            skipInitial = 1;
+            skipBetween = 0;
+        } else if (colorString.startsWith("rgb:")) {
+            // rgb:<red>/<green>/<blue> where <red>, <green>, <blue> := h | hh | hhh | hhhh. Scaled.
+            skipInitial = 4;
+            skipBetween = 1;
+        } else {
+            throw new IllegalArgumentException("Wrong Prefix Format: '" + colorString + "'");
+        }
 
+        return parseRGB(colorString, skipInitial, skipBetween);
+    }
+
+    private static int getComponentLength(String colorString, int skipInitial, int skipBetween) {
+        int charsForColors = colorString.length() - skipInitial - 2 * skipBetween;
+        if (charsForColors % 3 != 0) {
+            throw new IllegalArgumentException("Unequal Length: '" + colorString + "'");
+        }
+        return charsForColors / 3;
+    }
+
+    private static int parseRGB(String colorString, int skipInitial, int skipBetween) {
+        final int componentLength = getComponentLength(colorString, skipInitial, skipBetween);
+        final double mult = 255 / (Math.pow(2, componentLength * 4) - 1);
+        try {
             int currentPosition = skipInitial;
             String rString = colorString.substring(currentPosition, currentPosition + componentLength);
             currentPosition += componentLength + skipBetween;

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColors.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColors.java
@@ -81,7 +81,11 @@ public final class TerminalColors {
 
     /** Try parse a color from a text parameter and into a specified index. */
     public void tryParseColor(int intoIndex, String textParameter) {
-        mCurrentColors[intoIndex] = parse(textParameter);
+        try {
+            mCurrentColors[intoIndex] = parse(textParameter);
+        } catch (IllegalArgumentException e) {
+            // Ignore.
+        }
     }
 
 }

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColors.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColors.java
@@ -32,45 +32,48 @@ public final class TerminalColors {
      * <p/>
      * Highest bit is set if successful, so return value is 0xFF${R}${G}${B}. Return 0 if failed.
      */
-    static int parse(String c) {
+    static int parse(String colorString) {
         try {
             int skipInitial, skipBetween;
-            if (c.charAt(0) == '#') {
+            if (colorString.charAt(0) == '#') {
                 // #RGB, #RRGGBB, #RRRGGGBBB or #RRRRGGGGBBBB. Most significant bits.
                 skipInitial = 1;
                 skipBetween = 0;
-            } else if (c.startsWith("rgb:")) {
+            } else if (colorString.startsWith("rgb:")) {
                 // rgb:<red>/<green>/<blue> where <red>, <green>, <blue> := h | hh | hhh | hhhh. Scaled.
                 skipInitial = 4;
                 skipBetween = 1;
             } else {
-                return 0;
+                throw new IllegalArgumentException("Wrong Prefix Format: '" + colorString + "'");
             }
-            int charsForColors = c.length() - skipInitial - 2 * skipBetween;
-            if (charsForColors % 3 != 0) return 0; // Unequal lengths.
+            int charsForColors = colorString.length() - skipInitial - 2 * skipBetween;
+            if (charsForColors % 3 != 0) {
+                throw new IllegalArgumentException("Unequal Length: '" + colorString + "'");
+            }
             int componentLength = charsForColors / 3;
             double mult = 255 / (Math.pow(2, componentLength * 4) - 1);
 
             int currentPosition = skipInitial;
-            String rString = c.substring(currentPosition, currentPosition + componentLength);
+            String rString = colorString.substring(currentPosition, currentPosition + componentLength);
             currentPosition += componentLength + skipBetween;
-            String gString = c.substring(currentPosition, currentPosition + componentLength);
+            String gString = colorString.substring(currentPosition, currentPosition + componentLength);
             currentPosition += componentLength + skipBetween;
-            String bString = c.substring(currentPosition, currentPosition + componentLength);
+            String bString = colorString.substring(currentPosition, currentPosition + componentLength);
 
             int r = (int) (Integer.parseInt(rString, 16) * mult);
             int g = (int) (Integer.parseInt(gString, 16) * mult);
             int b = (int) (Integer.parseInt(bString, 16) * mult);
             return 0xFF << 24 | r << 16 | g << 8 | b;
-        } catch (NumberFormatException | IndexOutOfBoundsException e) {
-            return 0;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("NumberFormatException: '" + colorString + "'");
+        } catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException("IndexOutOfBoundsException: '" + colorString + "'");
         }
     }
 
     /** Try parse a color from a text parameter and into a specified index. */
     public void tryParseColor(int intoIndex, String textParameter) {
-        int c = parse(textParameter);
-        if (c != 0) mCurrentColors[intoIndex] = c;
+        mCurrentColors[intoIndex] = parse(textParameter);
     }
 
 }

--- a/terminal-emulator/src/test/java/com/termux/terminal/TerminalTest.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/TerminalTest.java
@@ -250,8 +250,18 @@ public class TerminalTest extends TerminalTestCase {
 		assertEquals(0xFF0000FA, TerminalColors.parse("rgb:00/00/FA"));
 		assertEquals(0xFF53186f, TerminalColors.parse("rgb:53/18/6f"));
 
-		assertEquals(0, TerminalColors.parse("invalid_0000FA"));
-		assertEquals(0, TerminalColors.parse("#3456"));
+        try {
+            TerminalColors.parse("invalid_0000FA");
+            fail();
+        } catch (IllegalArgumentException e) {
+            // pass
+        }
+        try {
+            TerminalColors.parse("#3456");
+            fail();
+        } catch (IllegalArgumentException e) {
+            // pass
+        }
 	}
 
 	/** The ncurses library still uses this. */


### PR DESCRIPTION
Splitted codes according to each steps for readability and included only the parts that make sense for the try-catch.

Also added try-catch statements for handling exception.
`tryParseColor()` from `TerminalColors.java` and `updateWith()` from `TerminalColorScheme.java` are wrapped by try-catch because they didn't actually try.
In `TerminalTest.java`, testing wrong input code block is wrapped by try-catch.