### PR TITLE
Basic MIME type recognition in ContentProvider

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxOpenReceiver.java
+++ b/app/src/main/java/com/termux/app/TermuxOpenReceiver.java
@@ -172,6 +172,13 @@ public class TermuxOpenReceiver extends BroadcastReceiver {
 
         @Override
         public String getType(@NonNull Uri uri) {
+            String path = uri.getLastPathSegment();
+            int extIndex = path.lastIndexOf('.') + 1;
+            if (extIndex > 0) {
+                MimeTypeMap mimeMap = MimeTypeMap.getSingleton();
+                String ext = path.substring(extIndex).toLowerCase();
+                return mimeMap.getMimeTypeFromExtension(ext);
+            }
             return null;
         }
 


### PR DESCRIPTION
This fixes apps that rely on [getType](https://developer.android.com/reference/android/content/ContentResolver#getType(android.net.Uri)), for example [WallpaperPicker2](https://cs.android.com/android/platform/superproject/+/master:packages/apps/WallpaperPicker2/src/com/android/wallpaper/asset/ContentUriAsset.java;l=158;bpv=1;bpt=1?q=isJpeg).