### PR TITLE
Clear LineWrap flag when clearing lines using blockSet.

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -439,9 +439,13 @@ public final class TerminalBuffer {
             throw new IllegalArgumentException(
                 "Illegal arguments! blockSet(" + sx + ", " + sy + ", " + w + ", " + h + ", " + val + ", " + mColumns + ", " + mScreenRows + ")");
         }
-        for (int y = 0; y < h; y++)
+        for (int y = 0; y < h; y++) {
             for (int x = 0; x < w; x++)
                 setChar(sx + x, sy + y, val, style);
+            if (sx+w == mColumns && val == ' ') {
+                clearLineWrap(sy + y);
+            }
+        }
     }
 
     public TerminalRow allocateFullLineIfNecessary(int row) {


### PR DESCRIPTION
This commit resets a row's mLineWrapped flag, if the last column is cleared with spaces.

Without this the flag remains from a previous line after clearing, for example on escape sequence `\e[2J`.

To see the bug:
1. Open termux (with font large enough for some of the message lines to wrap).
2. run `clear ; ls /`
3. press `ctrl+alt+=` to increase font size.

Notice that the some of the ls lines are now not left aligned.