### PR TITLE
Add LastPendingIntentRequestCode support to TermuxAPIAppSharedPreferences

### DIFF
--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxAPIAppSharedPreferences.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxAPIAppSharedPreferences.java
@@ -72,4 +72,13 @@ public class TermuxAPIAppSharedPreferences extends AppSharedPreferences {
         SharedPreferenceUtils.setInt(mSharedPreferences, TERMUX_API_APP.KEY_LOG_LEVEL, logLevel, commitToFile);
     }
 
+
+    public int getLastPendingIntentRequestCode() {
+        return SharedPreferenceUtils.getInt(mSharedPreferences, TERMUX_API_APP.KEY_LAST_PENDING_INTENT_REQUEST_CODE, TERMUX_API_APP.DEFAULT_VALUE_KEY_LAST_PENDING_INTENT_REQUEST_CODE);
+    }
+
+    public void setLastPendingIntentRequestCode(int lastPendingIntentRequestCode) {
+        SharedPreferenceUtils.setInt(mSharedPreferences, TERMUX_API_APP.KEY_LAST_PENDING_INTENT_REQUEST_CODE, lastPendingIntentRequestCode, true);
+    }
+
 }

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxPreferenceConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxPreferenceConstants.java
@@ -194,6 +194,13 @@ public final class TermuxPreferenceConstants {
          */
         public static final String KEY_LOG_LEVEL = "log_level";
 
+
+        /**
+         * Defines the key for last used PendingIntent request code.
+         */
+        public static final String KEY_LAST_PENDING_INTENT_REQUEST_CODE = "last_pending_intent_request_code";
+        public static final int DEFAULT_VALUE_KEY_LAST_PENDING_INTENT_REQUEST_CODE = 0;
+
     }
 
 


### PR DESCRIPTION
For use with https://github.com/termux/termux-api/pull/556 and https://github.com/termux/termux-api-package/pull/161

See https://github.com/termux/termux-api/issues/550 and https://github.com/termux/termux-api/issues/246