### PR TITLE
feat(KeyHandler): respect modifiers with PgUp and PgDn

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/KeyHandler.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/KeyHandler.java
@@ -227,9 +227,9 @@ public final class KeyHandler {
                 return transformForModifiers("\033[3", keyMode, '~');
 
             case KEYCODE_PAGE_UP:
-                return "\033[5~";
+                return transformForModifiers("\033[5", keyMode, '~');
             case KEYCODE_PAGE_DOWN:
-                return "\033[6~";
+                return transformForModifiers("\033[6", keyMode, '~');
             case KEYCODE_DEL:
                 String prefix = ((keyMode & KEYMOD_ALT) == 0) ? "" : "\033";
                 // Just do what xterm and gnome-terminal does:


### PR DESCRIPTION
Don't know why didn't anyone else report this. It's a pretty common keybinding for working with tabs on most applications. The fix is unsurprisingly simple.
