### PR TITLE
Separate the build targets INCOMPLETE 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,6 +93,9 @@ android {
 
         debug {
             signingConfig signingConfigs.debug
+            applicationIdSuffix ".debug"
+            manifestPlaceholders.TERMUX_PACKAGE_NAME = "com.termux.debug"
+            manifestPlaceholders.TERMUX_APP_NAME = "Termux Debug"
         }
     }
 


### PR DESCRIPTION
I think I can ask for some minor apartheid. As usual everything in this world surprise me. The bottom line is I need to have a separate build target. This is incomplete if somebody has the energy or computer.   ... I am currently on my phone all summer. .... Horrible allergies ... The debug build still call some of the other the main window... You understand.

There has to be a free build target that is not blocked by the signature. I'm not going to uninstall the entire thing or whatever it doesn't make any sense