### PR TITLE
added support to remove the termux window from the recent apps menu on EOF

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,7 +58,12 @@
             android:launchMode="singleTask"
             android:resizeableActivity="true"
             android:theme="@style/Theme.TermuxActivity.DayNight.NoActionBar"
+<<<<<<< Updated upstream
             tools:targetApi="n">
+=======
+            android:excludeFromRecents="true"
+        tools:targetApi="n">
+>>>>>>> Stashed changes
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION


android:excludeFromRecents="true": Ensures that the activity is excluded from the list of recent apps when it finishes.