### PR TITLE
Add support for apps supporting PROCESS_TEXT intents.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -233,4 +233,14 @@
 
     </application>
 
+    <!-- Starting with api level 30, we need to declare intent actions inside a queries element, 
+    to be able to find activities which support a given intent
+    https://developer.android.com/training/package-visibility/use-cases#custom-text-selection-actions -->
+    <queries>
+        <intent>
+          <action android:name="android.intent.action.PROCESS_TEXT" />
+          <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
+
 </manifest>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <string name="msg_generating_report">Generating Report</string>
     <string name="msg_add_termux_debug_info">Add termux debug info to report?</string>
 
+    <string name="action_process_text">Select text processing app…</string>
+
     <string name="error_styling_not_installed">The &TERMUX_STYLING_APP_NAME; Plugin App is not installed.</string>
     <string name="action_styling_install">Install</string>
 

--- a/termux-shared/src/main/java/com/termux/shared/interact/ProcessTextUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/interact/ProcessTextUtils.java
@@ -1,0 +1,69 @@
+package com.termux.shared.interact;
+
+import android.annotation.TargetApi;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.os.Build;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProcessTextUtils {
+
+    /**
+     * Data required to interact with an activity that supports the PROCESS_TEXT intent.
+     */
+    public static class ProcessTextActivityData {
+        /**
+         * The label of the external app activity.
+         */
+        public final CharSequence label;
+
+        /**
+         * The intent to launch the activity.
+         */
+        public final Intent intent;
+
+        private ProcessTextActivityData(CharSequence label, Intent intent) {
+            this.label = label;
+            this.intent = intent;
+        }
+    }
+
+    /**
+     * Retrieve a list of activities (including outside of this app) that support the
+     * {@link Intent#ACTION_PROCESS_TEXT} intent action. For each item in the returned
+     * list, its Intent can be used to launch the activity with the given text.
+     *
+     * @param context The context for operations
+     * @param text    The text to send in the Intents for the supported activities.
+     * @return a List of {@link ProcessTextActivityData} for supported activities.
+     */
+    @TargetApi(Build.VERSION_CODES.M)
+    public static List<ProcessTextActivityData> getProcessTextActivities(Context context, String text) {
+        PackageManager packageManager = context.getPackageManager();
+        Intent processTextIntent = new Intent(Intent.ACTION_PROCESS_TEXT);
+        processTextIntent.setType("text/plain");
+        List<ResolveInfo> activities = packageManager.queryIntentActivities(processTextIntent, PackageManager.MATCH_ALL);
+        List<ProcessTextActivityData> result = new ArrayList<>();
+        for (ResolveInfo resolveInfo : activities) {
+            CharSequence label = resolveInfo.loadLabel(packageManager);
+            result.add(new ProcessTextActivityData(label, createProcessTextIntentForPackage(resolveInfo.activityInfo, text)));
+        }
+        return result;
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private static Intent createProcessTextIntentForPackage(ActivityInfo activityInfo, String text) {
+        Intent intent = new Intent(Intent.ACTION_PROCESS_TEXT);
+        intent.setComponent(new ComponentName(activityInfo.packageName, activityInfo.name));
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_PROCESS_TEXT, text);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        return intent;
+    }
+}


### PR DESCRIPTION
In the context menu that appears when a user selects text, add a new submenu which includes third-party activities which handle the `PROCESS_TEXT` intent. This will allow processing the selected text in other apps.

Some links about this type of interaction with other apps:
* Manifest config required to work on Android 30+: https://developer.android.com/training/package-visibility/use-cases
* `PROCESS_TEXT` intent action: https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT)
* Blog post by Ian Lake on how to make an app appear in the system text selection menu: https://medium.com/androiddevelopers/custom-text-selection-actions-with-action-process-text-191f792d2999

Since the text selection menu is customized in termux, if we want the text selection menu to include this functionality, we have to add it ourselves (this commit :) ).

Here's a demo of selecting text, and opening it in Google Translate, then in Wikipedia:

[process_text.webm](https://github.com/termux/termux-app/assets/1731388/e6bc5993-a421-49f2-b868-41cfee0afe68)
