### PR TITLE
Changed: Migrating to ChickenHook RestrictionBypass

### DIFF
--- a/termux-shared/build.gradle
+++ b/termux-shared/build.gradle
@@ -14,7 +14,7 @@ android {
         implementation "io.noties.markwon:ext-strikethrough:$markwonVersion"
         implementation "io.noties.markwon:linkify:$markwonVersion"
         implementation "io.noties.markwon:recycler:$markwonVersion"
-        implementation "org.lsposed.hiddenapibypass:hiddenapibypass:2.0"
+        implementation "com.github.ChickenHook:RestrictionBypass:2.2"
 
         // Do not increment version higher than 1.0.0-alpha09 since it will break ViewUtils and needs to be looked into
         // noinspection GradleDependency

--- a/termux-shared/src/main/java/com/termux/shared/reflection/ReflectionUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/reflection/ReflectionUtils.java
@@ -7,7 +7,7 @@ import androidx.annotation.Nullable;
 
 import com.termux.shared.logger.Logger;
 
-import org.lsposed.hiddenapibypass.HiddenApiBypass;
+import org.chickenhook.restrictionbypass.Unseal;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -22,14 +22,14 @@ public class ReflectionUtils {
 
     /**
      * Bypass android hidden API reflection restrictions.
-     * https://github.com/LSPosed/AndroidHiddenApiBypass
+     * https://github.com/ChickenHook/RestrictionBypass
      * https://developer.android.com/guide/app-compatibility/restrictions-non-sdk-interfaces
      */
     public static void bypassHiddenAPIReflectionRestrictions() {
         if (!HIDDEN_API_REFLECTION_RESTRICTIONS_BYPASSED && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             Logger.logDebug(LOG_TAG, "Bypassing android hidden api reflection restrictions");
             try {
-                HiddenApiBypass.addHiddenApiExemptions("");
+                Unseal.unseal();
             } catch (Throwable t) {
                 Logger.logStackTraceWithMessage(LOG_TAG, "Failed to bypass hidden API reflection restrictions", t);
             }


### PR DESCRIPTION
LSPosed Hiddenapi Bypass uses sun.misc.Unsafe, which is not good, it is literally unsafe, and may be removed in future. 
For bypassing hiddenapi, there is a safer way on Chickenhook Restriction Bypass lib.

References:
- https://github.com/ChickenHook/RestrictionBypass

 - https://blogs.oracle.com/javamagazine/post/the-unsafe-class-unsafe-at-any-speed

 - https://androidreverse.org/blog/2023/02/21/android-api-restriction-bypass-for-all-android-versions/

 - https://developer.android.com/distribute/best-practices/develop/restrictions-non-sdk-interfaces