### PR TITLE
Added java.io export to gradle.properties to fix app not compiling on latest gradle versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,12 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx2048M
+org.gradle.jvmargs=-Xmx2048M \
+--add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.io=ALL-UNNAMED \
+--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
 android.useAndroidX=true
 
 minSdkVersion=21


### PR DESCRIPTION
This will fix the error on andorid studio latest versions

"Unable to make field private final java.lang.String java.io.File.path accessible:
 Unable to make field private final java.lang.String java.io.File.path
 accessible: module java.base does not "opens java.io" to unnamed module @42760a00"