### PR TITLE
Fixed: Widen TerminalRow's index so very long lines don't overflow it.

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/WcWidth.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/WcWidth.java
@@ -538,4 +538,29 @@ public final class WcWidth {
         return Character.isHighSurrogate(c) ? width(Character.toCodePoint(c, chars[index + 1])) : width(c);
     }
 
+    /**
+     * The zero width characters count like combining characters in the `chars` array from start
+     * index to end index (exclusive).
+     */
+    public static int zeroWidthCharsCount(char[] chars, int start, int end) {
+        if (start < 0 || start >= chars.length)
+            return 0;
+
+        int count = 0;
+        for (int i = start; i < end && i < chars.length;) {
+            if (Character.isHighSurrogate(chars[i])) {
+                if (width(Character.toCodePoint(chars[i], chars[i + 1])) <= 0) {
+                    count++;
+                }
+                i += 2;
+            } else {
+                if (width(chars[i]) <= 0) {
+                    count++;
+                }
+                i++;
+            }
+        }
+        return count;
+    }
+
 }


### PR DESCRIPTION
This prevents the crash in #3839, but not by enough to call it done. Termux gets stuck on the very bad line and is responsive, but laggy enough to trigger ANRs. It's possible to ^C in this state and get your terminal back with no apparent damage.