### PR TITLE
termux-app is not booted and not properly working in background on Android 10 (on Xiaomi Redmi 7A)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -196,7 +196,8 @@
 
         <service
             android:name=".app.TermuxService"
-            android:exported="false" />
+            android:exported="true"
+            android:enabled="true" />
 
         <service
             android:name=".app.RunCommandService"

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -159,10 +159,9 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
                     break;
             }
         }
-
-        // If this service really do get killed, there is no point restarting it automatically - let the user do on next
-        // start of {@link Term):
-        return Service.START_NOT_STICKY;
+        // If Service.START_NOT_STICKY is used this service will be killed when device not connected to charger
+        // (probably only for Xiaomi Redmi 7A with Android 10)
+        return Service.START_STICKY;
     }
 
     @Override

--- a/app/src/main/java/com/termux/app/event/SystemEventReceiver.java
+++ b/app/src/main/java/com/termux/app/event/SystemEventReceiver.java
@@ -5,10 +5,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.Uri;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.termux.app.TermuxService;
 import com.termux.shared.data.IntentUtils;
 import com.termux.shared.logger.Logger;
 import com.termux.shared.termux.TermuxUtils;
@@ -51,8 +53,20 @@ public class SystemEventReceiver extends BroadcastReceiver {
         }
     }
 
+    private void runTermuxService(@NonNull Context context) {
+        Intent serviceIntent = new Intent(context, TermuxService.class);
+        // O is Oreo, Android 8
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(serviceIntent);
+        }
+        else {
+            context.startService(serviceIntent);
+        }
+    }
+
     public synchronized void onActionBootCompleted(@NonNull Context context, @NonNull Intent intent) {
         TermuxShellManager.onActionBootCompleted(context, intent);
+        runTermuxService(context);
     }
 
     public synchronized void onActionPackageUpdated(@NonNull Context context, @NonNull Intent intent) {


### PR DESCRIPTION
For details see:
https://stackoverflow.com/a/19856267/1455694
https://stackoverflow.com/a/63250729/1455694
https://www.reddit.com/r/tasker/comments/d7whyj/android_10_and_auto_starting_apps/
https://stackoverflow.com/q/64642362/1455694

Not sure about real need for:
            android:enabled="true"
            android:exported="true"
in app/src/main/AndroidManifest.xml

Related pull request for termux-boot:
termux-boot is not working on Xiaomi Redmi 7A on Android 10
https://github.com/termux/termux-boot/pull/195