### PR TITLE
bug-report-template: scream that this is not the place to report bugs about packages

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -6,7 +6,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        This is a bug tracker of the Termux app. If you have issues with a package inside the app, then please open an issue at [termux-packages](https://github.com/termux/termux-packages) instead.
+        **THIS IS A BUG TRACKER OF THE TERMUX APP. IF YOU HAVE ISSUES WITH A PACKAGE INSIDE THE APP, THEN PLEASE OPEN AN ISSUE AT [TERMUX/TERMUX-PACKAGES](https://github.com/termux/termux-packages) INSTEAD.**
+        If you are unsure if this is a bug with the Termux app itself or any of the packages, kindly open up the bug at [termux/termux-packages](https://github.com/termux/termux-packages) as it's very likely that it belongs there.
 
         Use search before you open an issue to check whether your issue has been already reported and perhaps solved.
 


### PR DESCRIPTION
I'm seeing a lot of bug reports that should have been made to termux/termux-packages, but people don't just read things not written in BOLD and caps it seems. So now scream out, so that they do read.

Also direct confused users to termux/termux-packages, in case it does actually belong to termux/termux-app, we can always transfer the issue there