### PR TITLE
Add note about play store alpha 0.120

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The core [Termux](https://github.com/termux/termux-app) app comes with the follo
 
 ## Installation
 
-Latest version is `v0.118.0`.
+Latest version is `v0.118.0`. The version `v0.120.0` released on Play Store is an *early alpha* not ready for general use. ([details](https://github.com/termux/termux-app/discussions/3995))
 
 **NOTICE: It is highly recommended that you update to `v0.118.0` or higher ASAP for various bug fixes, including a critical world-readable vulnerability reported [here](https://termux.github.io/general/2022/02/15/termux-apps-vulnerability-disclosures.html). Also reminding [again](https://www.reddit.com/r/termux/comments/pkujfa/important_deprecation_notice_for_google_play) to users who have installed termux apps from google playstore that playstore builds are [deprecated](#google-play-store-deprecated) and no longer supported. It is recommended that you shift to F-Droid or GitHub releases.**
 


### PR DESCRIPTION
Adds a small note to the readme about the alpha version that was released to play store.

Play store seems seems to be advertising this upgrade to users who have installed termux via other channels, I'm suggesting this change in the hopes that some of them will see the readme and not have to ask about it.

Feel free to discard this, edit it, or copy it. I have no particular interest in this PR beyond suggesting it. 