### PR TITLE
0.118: bump bootstraps to v2024.06.09-r1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -195,11 +195,11 @@ clean {
 
 task downloadBootstraps() {
     doLast {
-        def version = "2022.01.07-r1"
-        downloadBootstrap("aarch64", "0fe6d0159d12fcb8baf7750ce9072b9b36f742662b02ad4da145ab85873614cd", version)
-        downloadBootstrap("arm",     "0a6014e2ec3b7079524fee3caabd02be05bcb4add3c6cd9e5ad98408b428c717", version)
-        downloadBootstrap("i686",    "c55369a9af1316dc3d99457aa23cce64b29c1e60e375159352c0d4b9cfed4ac6", version)
-        downloadBootstrap("x86_64",  "e93a7c66d15edb7d1b5ceca906255c85ead35a8b6a52f93524e117cfb07e6778", version)
+        def version = "2024.06.09-r1" + "+apt-android-7"
+        downloadBootstrap("aarch64", "23390696860d0375729b65cc11a13fed1a04a480071bdcdd7e307ab3f1cff419", version)
+        downloadBootstrap("arm",     "f85c846fd3718f4fc54f3aebf28f93394b2a05e33c9d104437a06dc631037f94", version)
+        downloadBootstrap("i686",    "f4008384b64d2e47c2cd4d49d2229744f76af81e404fab0066ab4679503dc6de", version)
+        downloadBootstrap("x86_64",  "78eebd6b9719a1092d1a874c2de425399601cc88a9e91e6d010e6bfd6c54d8f1", version)
     }
 }
 


### PR DESCRIPTION
Installation and pkg/apt usage, and general use, works fine on both arm and aarch64