### PR TITLE
Added: Advanced Mouse Mode setting

### DIFF
--- a/app/src/main/java/com/termux/app/fragments/settings/termux/TerminalIOPreferencesFragment.java
+++ b/app/src/main/java/com/termux/app/fragments/settings/termux/TerminalIOPreferencesFragment.java
@@ -60,6 +60,9 @@ class TerminalIOPreferencesDataStore extends PreferenceDataStore {
             case "soft_keyboard_enabled_only_if_no_hardware":
                 mPreferences.setSoftKeyboardEnabledOnlyIfNoHardware(value);
                 break;
+            case "advanced_mouse":
+                mPreferences.setAdvancedMouse(value);
+                break;
             default:
                 break;
         }
@@ -74,6 +77,8 @@ class TerminalIOPreferencesDataStore extends PreferenceDataStore {
                 return mPreferences.isSoftKeyboardEnabled();
             case "soft_keyboard_enabled_only_if_no_hardware":
                 return mPreferences.isSoftKeyboardEnabledOnlyIfNoHardware();
+            case "advanced_mouse":
+                return mPreferences.isAdvancedMouse();
             default:
                 return false;
         }

--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
@@ -101,6 +101,11 @@ public class TermuxTerminalViewClient extends TermuxTerminalViewClientBase {
         boolean isTerminalViewKeyLoggingEnabled = mActivity.getPreferences().isTerminalViewKeyLoggingEnabled();
         mActivity.getTerminalView().setIsTerminalViewKeyLoggingEnabled(isTerminalViewKeyLoggingEnabled);
 
+        // Set {@link TerminalView#ADVANCED_MOUSE} value
+        // Also required if user changed the preference from {@link TermuxSettings} activity and returns
+        boolean isAdvancedMouse = mActivity.getPreferences().isAdvancedMouse();
+        mActivity.getTerminalView().setAdvancedMouse(isAdvancedMouse);
+
         // Piggyback on the terminal view key logging toggle for now, should add a separate toggle in future
         mActivity.getTermuxActivityRootView().setIsRootViewLoggingEnabled(isTerminalViewKeyLoggingEnabled);
         ViewUtils.setIsViewUtilsLoggingEnabled(isTerminalViewKeyLoggingEnabled);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,15 @@
                     no hardware keyboard is connected.</string>
 
 
+            <!-- Mouse Category -->
+            <string name="termux_mouse_header">Mouse</string>
+
+                <!-- Touch Dragging -->
+                <string name="termux_advanced_mouse_title">Advanced Mouse Mode</string>
+                <string name="termux_advanced_mouse_off">Dragging the touch screen sends scroll wheel up/down events. (Default)</string>
+                <string name="termux_advanced_mouse_on">Dragging the touch screen sends mouse move events.</string>
+
+
         <!-- Terminal View Preferences -->
         <string name="termux_terminal_view_preferences_title">Terminal View</string>
         <string name="termux_terminal_view_preferences_summary">Preferences for terminal view</string>

--- a/app/src/main/res/xml/termux_terminal_io_preferences.xml
+++ b/app/src/main/res/xml/termux_terminal_io_preferences.xml
@@ -18,4 +18,15 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        app:key="mouse"
+        app:title="@string/termux_mouse_header">
+
+        <SwitchPreferenceCompat
+            app:key="advanced_mouse"
+            app:summaryOff="@string/termux_advanced_mouse_off"
+            app:summaryOn="@string/termux_advanced_mouse_on"
+            app:title="@string/termux_advanced_mouse_title" />
+
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -47,6 +47,9 @@ public final class TerminalView extends View {
     /** Log terminal view key and IME events. */
     private static boolean TERMINAL_VIEW_KEY_LOGGING_ENABLED = false;
 
+    /** Send full mouse events for dragging the touch screen, rather than scroll-wheep up/down */
+    private static boolean ADVANCED_MOUSE = false;
+
     /** The currently displayed terminal session, whose emulator is {@link #mEmulator}. */
     public TerminalSession mTermSession;
     /** Our terminal emulator whose session is {@link #mTermSession}. */
@@ -131,7 +134,8 @@ public final class TerminalView extends View {
             @Override
             public boolean onScroll(MotionEvent e, float distanceX, float distanceY) {
                 if (mEmulator == null) return true;
-                if (mEmulator.isMouseTrackingActive() && e.isFromSource(InputDevice.SOURCE_MOUSE)) {
+                if (ADVANCED_MOUSE || (mEmulator.isMouseTrackingActive() && e.isFromSource(InputDevice.SOURCE_MOUSE))) {
+                    // Unless using advanced mouse mode:
                     // If moving with mouse pointer while pressing button, report that instead of scroll.
                     // This means that we never report moving with button press-events for touch input,
                     // since we cannot just start sending these events without a starting press event,
@@ -240,6 +244,15 @@ public final class TerminalView extends View {
      */
     public void setIsTerminalViewKeyLoggingEnabled(boolean value) {
         TERMINAL_VIEW_KEY_LOGGING_ENABLED = value;
+    }
+
+    /**
+     * Sets whether dragging the touch screen sends mouse move events, or up/down scroll wheel
+     *
+     * @param value True to send mouse swipe events, false for scroll wheel
+     */
+    public void setAdvancedMouse(boolean value) {
+        ADVANCED_MOUSE = value;
     }
 
 

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxAppSharedPreferences.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxAppSharedPreferences.java
@@ -110,6 +110,14 @@ public class TermuxAppSharedPreferences extends AppSharedPreferences {
         SharedPreferenceUtils.setBoolean(mSharedPreferences, TERMUX_APP.KEY_SOFT_KEYBOARD_ENABLED_ONLY_IF_NO_HARDWARE, value, false);
     }
 
+    public boolean isAdvancedMouse() {
+        return SharedPreferenceUtils.getBoolean(mSharedPreferences, TERMUX_APP.KEY_ADVANCED_MOUSE, TERMUX_APP.DEFAULT_VALUE_KEY_ADVANCED_MOUSE);
+    }
+
+    public void setAdvancedMouse(boolean value) {
+        SharedPreferenceUtils.setBoolean(mSharedPreferences, TERMUX_APP.KEY_ADVANCED_MOUSE, value, false);
+    }
+
 
 
     public boolean shouldKeepScreenOn() {

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxPreferenceConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxPreferenceConstants.java
@@ -1,7 +1,7 @@
 package com.termux.shared.termux.settings.preferences;
 
 /*
- * Version: v0.16.0
+ * Version: v0.17.0
  *
  * Changelog
  *
@@ -69,6 +69,10 @@ package com.termux.shared.termux.settings.preferences;
  * - 0.16.0 (2022-06-11)
  *      - Added following to `TERMUX_APP`:
  *          `KEY_APP_SHELL_NUMBER_SINCE_BOOT` and `KEY_TERMINAL_SESSION_NUMBER_SINCE_BOOT`.
+ *
+ * - 0.17.0 (2024-08-07)
+ *      - Added following to `TERMUX_APP`:
+ *          `KEY_ADVANCED_MOUSE` and `DEFAULT_VALUE_KEY_ADVANCED_MOUSE`
  */
 
 import com.termux.shared.shell.command.ExecutionCommand;
@@ -117,6 +121,12 @@ public final class TermuxPreferenceConstants {
         public static final String KEY_SOFT_KEYBOARD_ENABLED_ONLY_IF_NO_HARDWARE = "soft_keyboard_enabled_only_if_no_hardware";
         public static final boolean DEFAULT_VALUE_KEY_SOFT_KEYBOARD_ENABLED_ONLY_IF_NO_HARDWARE = false;
 
+
+        /**
+         * Defines the key for whether dragging the touch screen sends full mouse events instead of scroll wheel up/down
+         */
+        public static final String KEY_ADVANCED_MOUSE = "advanced_mouse";
+        public static final boolean DEFAULT_VALUE_KEY_ADVANCED_MOUSE = false;
 
         /**
          * Defines the key for whether to always keep screen on.


### PR DESCRIPTION
Adds a setting so users can choose whether dragging the touch screen sends mouse move events, or scroll wheel up/down. Defaults to scroll wheel (the old behavior).

Closes #1384

"Advanced Mouse Mode" doesn't seem like a great name, maybe something like "Scroll Mode" would be better?