### PR TITLE
Improve accessibility of the Terminal View by making Reading Mode navigation more intuitive and adding accessibility actions for the context menu

### DIFF
--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Typeface;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
@@ -27,11 +28,14 @@ import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewTreeObserver;
 import android.view.accessibility.AccessibilityManager;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.autofill.AutofillValue;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.widget.Scroller;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -221,6 +225,10 @@ public final class TerminalView extends View {
         mScroller = new Scroller(context);
         AccessibilityManager am = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
         mAccessibilityEnabled = am.isEnabled();
+
+        // A view is important for accessibility if it fires accessibility events
+        // and if it is reported to accessibility services that query the screen.
+        setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
     }
 
 
@@ -457,8 +465,123 @@ public final class TerminalView extends View {
         mEmulator.clearScrollCounter();
 
         invalidate();
-        if (mAccessibilityEnabled) setContentDescription(getText());
+        if (mAccessibilityEnabled) {
+            // fire off events that the content of this control changed,
+            // so that the accessibility service gets the updated text
+            sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED);
+        }
     }
+
+    // ultimately called as a result of the code in updateScreen
+    @Override
+    public void onPopulateAccessibilityEvent(AccessibilityEvent event) {
+        super.onPopulateAccessibilityEvent(event);
+
+        // add our (most up to date) text
+        final CharSequence text = getText();
+        if (!TextUtils.isEmpty(text)) {
+            event.getText().add(text);
+        }
+    }
+
+    // called by accessibility service exploring what's available
+    @Override
+    public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo node) {
+        super.onInitializeAccessibilityNodeInfo(node);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            node.setImportantForAccessibility(true);
+        }
+
+        final CharSequence text = getText();
+        node.setText(text);
+
+        // why only if text is non-empty? cargo cult, core TextView does this check,
+        // and the accessibility guide example also does this check, who am I to argue
+        if (!TextUtils.isEmpty(text)) {
+            // all granularities are valid, don't let the accessibility system guess;
+            // this allows a TalkBack user to navigate by char/word/paragraph within
+            // the TerminalView text only without accidently breaking out; other navigation
+            // modes such as default/controls allow you to move to other controls
+            node.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_NEXT_AT_MOVEMENT_GRANULARITY);
+            node.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_PREVIOUS_AT_MOVEMENT_GRANULARITY);
+            node.setMovementGranularities(AccessibilityNodeInfo.MOVEMENT_GRANULARITY_CHARACTER
+                | AccessibilityNodeInfo.MOVEMENT_GRANULARITY_WORD
+                | AccessibilityNodeInfo.MOVEMENT_GRANULARITY_LINE
+                | AccessibilityNodeInfo.MOVEMENT_GRANULARITY_PARAGRAPH
+                | AccessibilityNodeInfo.MOVEMENT_GRANULARITY_PAGE);
+
+            // add more selection actions
+            node.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_SET_SELECTION);
+            node.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_CLEAR_SELECTION);
+        }
+
+        // behave more like a multiline text view
+        node.setEditable(true);
+        node.setMultiLine(true);
+        node.setScrollable(true);
+        node.setCanOpenPopup(true);
+
+        // add actions that you can do on this thing
+        node.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_CLICK);
+        //node.addAction(AccessibilityNodeInfo.ACTION_LONG_CLICK); // already added
+        node.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_FOCUS);
+        node.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_COPY);
+        node.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_PASTE);
+        node.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_SCROLL_FORWARD);
+        node.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_SCROLL_BACKWARD);
+
+        // Add an accessibility action to open the context menu, it's a bit hard to get to it;
+        node.addAction(new AccessibilityNodeInfo.AccessibilityAction(
+            R.id.a11y_show_termux_menu_id,
+            getResources().getString(R.string.termux_menu_text)));
+
+        // Add an action to copy terminal text.
+        // Using a different to the Copy action in the popup, which you can technically
+        // get to if someone tells you it's there. You can't have the same button label
+        // do different things in different contexts; hence, different label
+        node.addAction(new AccessibilityNodeInfo.AccessibilityAction(
+            R.id.a11y_copy_id,
+            getResources().getString(R.string.copy_screen_text)));
+
+        // Add an accessibility action to paste text
+        node.addAction(new AccessibilityNodeInfo.AccessibilityAction(
+            R.id.a11y_paste_id,
+            getResources().getString(R.string.paste_text)));
+    }
+
+    @Override
+    public boolean performAccessibilityAction(int action, Bundle args) {
+        // only handle custom actions here, the defaults implemented by super are good enough
+        if(action == R.id.a11y_show_termux_menu_id) {
+            showContextMenu();
+            return true;
+        } else if(action == R.id.a11y_paste_id) {
+            doPaste();
+            return true;
+        } else if(action == R.id.a11y_copy_id) {
+            // I can't quite figure out how to make TextSelectionHandleView and/or
+            // TextSelectionCursor accessible; and I can't figure out how to hook up
+            // with the Accessibility Selection (2 finger 2x tap & hold) either;
+            // so at least give people the option to copy the screen; the whole
+            // transcript might be too much, plus there's a share transcript option
+            // in the More... menu;
+            // 3 finger double tap works as copy, but editable fields elsewhere tend
+            // to offer a Copy accessibility option
+            ClipboardManager clipboard = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+            ClipData clip = ClipData.newPlainText("screen text", getText());
+            clipboard.setPrimaryClip(clip);
+            Toast toast = Toast.makeText(
+                getContext(),
+                getResources().getText(R.string.copied_to_clipboard_text),
+                Toast.LENGTH_SHORT);
+            toast.show();
+
+            return true;
+        }
+
+        return super.performAccessibilityAction(action, args);
+    }
+
 
     /** This must be called by the hosting activity in {@link Activity#onContextMenuClosed(Menu)}
      * when context menu for the {@link TerminalView} is started by
@@ -578,15 +701,7 @@ public final class TerminalView extends View {
                 if (action == MotionEvent.ACTION_DOWN) showContextMenu();
                 return true;
             } else if (event.isButtonPressed(MotionEvent.BUTTON_TERTIARY)) {
-                ClipboardManager clipboardManager = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
-                ClipData clipData = clipboardManager.getPrimaryClip();
-                if (clipData != null) {
-                    ClipData.Item clipItem = clipData.getItemAt(0);
-                    if (clipItem != null) {
-                        CharSequence text = clipItem.coerceToText(getContext());
-                        if (!TextUtils.isEmpty(text)) mEmulator.paste(text.toString());
-                    }
-                }
+                doPaste();
             } else if (mEmulator.isMouseTrackingActive()) { // BUTTON_PRIMARY.
                 switch (event.getAction()) {
                     case MotionEvent.ACTION_DOWN:
@@ -602,6 +717,18 @@ public final class TerminalView extends View {
 
         mGestureRecognizer.onTouchEvent(event);
         return true;
+    }
+
+    private void doPaste() {
+        ClipboardManager clipboardManager = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipData clipData = clipboardManager.getPrimaryClip();
+        if (clipData != null) {
+            ClipData.Item clipItem = clipData.getItemAt(0);
+            if (clipItem != null) {
+                CharSequence text = clipItem.coerceToText(getContext());
+                if (!TextUtils.isEmpty(text)) mEmulator.paste(text.toString());
+            }
+        }
     }
 
     @Override
@@ -987,6 +1114,7 @@ public final class TerminalView extends View {
     }
 
     private CharSequence getText() {
+        if (mEmulator == null) return "";
         return mEmulator.getScreen().getSelectedText(0, mTopRow, mEmulator.mColumns, mTopRow + mEmulator.mRows);
     }
 

--- a/terminal-view/src/main/res/values/ids.xml
+++ b/terminal-view/src/main/res/values/ids.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="a11y_copy_id" type="id" />
+    <item name="a11y_paste_id" type="id" />
+    <item name="a11y_show_termux_menu_id" type="id" />
+</resources>

--- a/terminal-view/src/main/res/values/strings.xml
+++ b/terminal-view/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
   <string name="paste_text">Paste</string>
   <string name="copy_text">Copy</string>
   <string name="text_selection_more">More…</string>
+  <string name="termux_menu_text">Termux Menu</string>
+  <string name="copy_screen_text">Copy Screen</string>
+  <string name="copied_to_clipboard_text">Screen copied to clipboard</string>
 </resources>


### PR DESCRIPTION
**tl;dr** it's a lot easier to read the output of the last command
and to get to the copy/paste/more... actions

## Problem

It's a bit yiffy to navigate the wall of text in the terminal view. As things
stand right now with content description, accessibility services see the
`TerminalView` as an opaque blob with a wall-of-text description. Since it's
a description, there is nothing locking you in the control when using reading
controls (like you would be in a `TextView`).

Additionally, if I read the documentation of `setContentDescription` right,
it is really meant to offer a description of non-textual elements, or of
irritatingly opaque content; *not* to be the content itself. This is probably
irrelevant, as the goal was to make it easier to get to the output of the
last command.

## Solution

It is also nigh impossible to notice the popup menu (copy/paste/more...)
if you don't... *see* it. It ends up at the end of the control stack and it
is not announced (if I understand correctly, you have to issue an accessibility
focus event, but the accessibility of the selection handle thing is a whole
different problem to the one I'm trying to solve here).

The goal was to make the `TerminalView` behave more like a text view:
- have reading controls (by line, word or line) available regardless of
  what the system guesses, within the terminal view itself
- don't accidently leave the terminal view when using reading controls
  too much (e.g. by word)
- ability to easily jump to end, by swiping up/back with reading controls
  after activating the view (since it no longer "escapes")
- note, reading controls are different to basic navigation; basic navigation
  let's you flick between the view, soft keys (CTRL, ALT etc), copy/paste/menu
  popup, your soft keyboard, etc; reading controls allow you to navigate
  a wall of text within a control, i.e. the terminal view
- added accessibility actions to open the More... menu and copy and paste
  actions; note, these are apparent if TalkBack is running

## Code Changes

Actual changes, on `TerminalView`:
- explicitly mark the view as important to accessibility, because it does
  things which are important to accessibility, and it is the main focus of
  the whole app. The documentation of that method asks to set the flag to
  `YES` if a view does any of the things below;
- call `sendAccessibilityEvent(TYPE_VIEW_TEXT_CHANGED)` when text changes
  and implement `onPopulateAccessibilityEvent` to let accessibility services
  know the text has changed (and what it changed to)
- implement `onInitializeAccessibilityNodeInfo` which is called by
  accessibility services to detect what is on screen; this gives us a chance
  to explain that this `TerminalView` is a multiline text container and not
  some random eye candy that may be skipped over
- no longer set content description, since we now set actual content by
  way of `AccessibilityNodeInfo` and `AccessibilityEvent`; replaced with
  all of the above
- added custom accessibility actions for copy (screen), paste, and
  open termux menu (the *More...* menu).  Accessibility Actions are something
  an Accessibility Service may query and present in a way that makes sense
  to the user. In the case of *TalkBack*, it has an *Actions* "reading mode"
- added new strings to `strings.xml` and added 3 new IDs to `ids.xml` to
  support the custom accessibility actions.
- refactor method out from `onTouchEvent`, branch `BUTTON_TERTIARY`,
  to use it for the accessibility paste action

## Limitations

The *Copy* action could be better. I had 6 goes at integrating with the
custom selection widget handle thing, I failed. So the *Copy*-accessibility
action will copy the screen as a compromise.

Something ought to be done about the side panel, since you rather have to
know it's there. But since the More... menu is now easily discoverable,
someone with TalkBack might stumble onto the Help panel and read that there's
a secret side panel on the left. That wouldn't be much different to the way
I myself discovered that sessions side panel on the left :-)

It would be worth adding landmarks for the terminalview, button bar and
side panel, but that's a different PR, since it probably needs to be done
in the Activity, not here.

There's also something iffy about the fact that `AccessibilityManager.isEnabled()`
is only checked at start up.  Maybe it should be documented somewhere that
accessibility is checked only at startup for performance reasons. For people
who turn TalkBack on after launching the app, it might appear broken, even
though it really isn't. I didn't want to touch that behaviour since it was
something requested in the review of [!344](https://github.com/termux/termux-app/pull/344#issuecomment-397458262). I am merely stating my dissent.

To add to `mAccessibilityEnabled`: the a11y related method overrides are
simply not called if there's no active accessibility service, hence no checks needed.

Someone also mused about having the terminal speak out text as it comes in,
but that's also a different PR, since it rather requires interplay between
the TerminalEmulator code and TerminalView (providing accessibility), plus
setting up a virtual view that is live; and I assume people might want to
turn that off / control verbosity, which is a lot of work, so... not in this
PR.

It is theoretically possible to do partial text updates in `onPopulateAccessibilityEvent`,
(instead of blasting away the whole screen each time you type a character)
but I'm not convinced it actually works the way I hope, and it requires a
lot of work to get there (see previous paragraph). So... not in this PR.

But this PR makes interacting with the TerminalView itself much nicer
if you can't see what you're doing, and there's no reason to require people
to see what they're doing in this case.