### PR TITLE
Fixed: Implement colon separated CSI parameters

### DIFF
--- a/terminal-emulator/src/test/java/com/termux/terminal/TerminalTest.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/TerminalTest.java
@@ -137,6 +137,11 @@ public class TerminalTest extends TerminalTestCase {
 	}
 
 	public void testSelectGraphics() {
+		selectGraphicsTestRun(';');
+		selectGraphicsTestRun(':');
+	}
+
+	public void selectGraphicsTestRun(char separator) {
 		withTerminalSized(5, 5);
 		enterString("\033[31m");
 		assertEquals(mTerminal.mForeColor, 1);
@@ -155,16 +160,20 @@ public class TerminalTest extends TerminalTestCase {
         // Check TerminalEmulator.parseArg()
         enterString("\033[31m\033[m");
         assertEquals(TextStyle.COLOR_INDEX_FOREGROUND, mTerminal.mForeColor);
-        enterString("\033[31m\033[;m");
+        enterString("\033[31m\033[;m".replace(';', separator));
         assertEquals(TextStyle.COLOR_INDEX_FOREGROUND, mTerminal.mForeColor);
         enterString("\033[31m\033[0m");
         assertEquals(TextStyle.COLOR_INDEX_FOREGROUND, mTerminal.mForeColor);
-        enterString("\033[31m\033[0;m");
+        enterString("\033[31m\033[0;m".replace(';', separator));
         assertEquals(TextStyle.COLOR_INDEX_FOREGROUND, mTerminal.mForeColor);
         enterString("\033[31;;m");
         assertEquals(TextStyle.COLOR_INDEX_FOREGROUND, mTerminal.mForeColor);
+        enterString("\033[31::m");
+        assertEquals(1, mTerminal.mForeColor);
         enterString("\033[31;m");
         assertEquals(TextStyle.COLOR_INDEX_FOREGROUND, mTerminal.mForeColor);
+        enterString("\033[31:m");
+        assertEquals(1, mTerminal.mForeColor);
         enterString("\033[31;;41m");
         assertEquals(TextStyle.COLOR_INDEX_FOREGROUND, mTerminal.mForeColor);
         assertEquals(1, mTerminal.mBackColor);
@@ -172,38 +181,38 @@ public class TerminalTest extends TerminalTestCase {
         assertEquals(TextStyle.COLOR_INDEX_BACKGROUND, mTerminal.mBackColor);
 
 		// 256 colors:
-		enterString("\033[38;5;119m");
+		enterString("\033[38;5;119m".replace(';', separator));
 		assertEquals(119, mTerminal.mForeColor);
 		assertEquals(TextStyle.COLOR_INDEX_BACKGROUND, mTerminal.mBackColor);
-		enterString("\033[48;5;129m");
+		enterString("\033[48;5;129m".replace(';', separator));
 		assertEquals(119, mTerminal.mForeColor);
 		assertEquals(129, mTerminal.mBackColor);
 
 		// Invalid parameter:
-		enterString("\033[48;8;129m");
+		enterString("\033[48;8;129m".replace(';', separator));
 		assertEquals(119, mTerminal.mForeColor);
 		assertEquals(129, mTerminal.mBackColor);
 
 		// Multiple parameters at once:
-		enterString("\033[38;5;178;48;5;179m");
+		enterString("\033[38;5;178".replace(';', separator) + ";" + "48;5;179m".replace(';', separator));
 		assertEquals(178, mTerminal.mForeColor);
 		assertEquals(179, mTerminal.mBackColor);
 
 		// Omitted parameter means zero:
-		enterString("\033[38;5;m");
+		enterString("\033[38;5;m".replace(';', separator));
 		assertEquals(0, mTerminal.mForeColor);
 		assertEquals(179, mTerminal.mBackColor);
-		enterString("\033[48;5;m");
+		enterString("\033[48;5;m".replace(';', separator));
 		assertEquals(0, mTerminal.mForeColor);
 		assertEquals(0, mTerminal.mBackColor);
 
 		// 24 bit colors:
 		enterString(("\033[0m")); // Reset fg and bg colors.
-		enterString("\033[38;2;255;127;2m");
+		enterString("\033[38;2;255;127;2m".replace(';', separator));
 		int expectedForeground = 0xff000000 | (255 << 16) | (127 << 8) | 2;
 		assertEquals(expectedForeground, mTerminal.mForeColor);
 		assertEquals(TextStyle.COLOR_INDEX_BACKGROUND, mTerminal.mBackColor);
-		enterString("\033[48;2;1;2;254m");
+		enterString("\033[48;2;1;2;254m".replace(';', separator));
 		int expectedBackground = 0xff000000 | (1 << 16) | (2 << 8) | 254;
 		assertEquals(expectedForeground, mTerminal.mForeColor);
 		assertEquals(expectedBackground, mTerminal.mBackColor);
@@ -212,24 +221,30 @@ public class TerminalTest extends TerminalTestCase {
 		enterString(("\033[0m")); // Reset fg and bg colors.
 		assertEquals(TextStyle.COLOR_INDEX_FOREGROUND, mTerminal.mForeColor);
 		assertEquals(TextStyle.COLOR_INDEX_BACKGROUND, mTerminal.mBackColor);
-		enterString("\033[38;2;255;127;2;48;2;1;2;254m");
+		enterString("\033[38;2;255;127;2".replace(';', separator) + ";" + "48;2;1;2;254m".replace(';', separator));
 		assertEquals(expectedForeground, mTerminal.mForeColor);
 		assertEquals(expectedBackground, mTerminal.mBackColor);
 
 		// 24 bit colors, invalid input:
-		enterString("\033[38;2;300;127;2;48;2;1;300;254m");
+		enterString("\033[38;2;300;127;2;48;2;1;300;254m".replace(';', separator));
 		assertEquals(expectedForeground, mTerminal.mForeColor);
 		assertEquals(expectedBackground, mTerminal.mBackColor);
 
 		// 24 bit colors, omitted parameter means zero:
-		enterString("\033[38;2;255;127;m");
+		enterString("\033[38;2;255;127;m".replace(';', separator));
 		expectedForeground = 0xff000000 | (255 << 16) | (127 << 8);
 		assertEquals(expectedForeground, mTerminal.mForeColor);
 		assertEquals(expectedBackground, mTerminal.mBackColor);
-		enterString("\033[38;2;123;;77m");
+		enterString("\033[38;2;123;;77m".replace(';', separator));
 		expectedForeground = 0xff000000 | (123 << 16) | 77;
 		assertEquals(expectedForeground, mTerminal.mForeColor);
 		assertEquals(expectedBackground, mTerminal.mBackColor);
+
+		// 24 bit colors, extra sub-parameters are skipped:
+		expectedForeground = 0xff000000 | (255 << 16) | (127 << 8) | 2;
+		enterString("\033[0;38:2:255:127:2:48:2:1:2:254m");
+		assertEquals(expectedForeground, mTerminal.mForeColor);
+		assertEquals(TextStyle.COLOR_INDEX_BACKGROUND, mTerminal.mBackColor);
 	}
 
 	public void testBackgroundColorErase() {


### PR DESCRIPTION
## Colon separated escape sequences for setting colors

It seems that more and more terminal emulators and terminal programs supports colon (`:`) as well as semicolon (`;`) to specify colors:

```sh
red=255 green=100 blue=0 
printf "\x1b[38;2;${red};${green};${blue}m TRUECOLOR\n" # Semicolon separated, works in Termux
printf "\x1b[38:2:${red}:${green}:${blue}m TRUECOLOR\n" # Colon separated, implemented in this PR
```

See https://github.com/termstandard/colors?tab=readme-ov-file#truecolor-support-in-output-devices, where it can be seen that multiple terminal emulators also support using a colon as delimiter nowadays:

- [alacritty](https://github.com/jwilm/alacritty) [delimiter: colon, semicolon] - written in Rust
- [iTerm2](https://iterm2.com/) [delimiter: colon, semicolon] - since v3 version
- [kitty](https://github.com/kovidgoyal/kitty) [delimiter: colon,semicolon] - uses OpenGL
- [konsole](https://konsole.kde.org/) [delimiter: colon, semicolon] - https://bugs.kde.org/show_bug.cgi?id=107487
- [xterm](https://invisible-island.net/xterm/) - (from [331 (change 330j)](https://invisible-island.net/xterm/xterm.log.html#xterm_331)
- All [libvte](https://download.gnome.org/sources/vte/) based terminals (since 0.36 version) [delimiter: colon, semicolon]
[..]

This is now implemented in Termux as well. Fixes https://github.com/termux/termux-packages/issues/20655, escape sequence issues with `vtm`.

See https://github.com/alacritty/vte/issues/22 for a discussion when this was implemented in `alacritty/vte`.

## Colored and styled underlines parsing

We also here start to parse [Colored and styled underlines](https://sw.kovidgoyal.net/kitty/underlines/) as initially proposed by Kitty:

> To set the underline style:
> 
>
> <ESC>[4:0m  # no underline
> <ESC>[4:1m  # straight underline
> <ESC>[4:2m  # double underline
> <ESC>[4:3m  # curly underline
> <ESC>[4:4m  # dotted underline
> <ESC>[4:5m  # dashed underline
> <ESC>[4m    # straight underline (for backwards compat)
> <ESC>[24m   # no underline (for backwards compat)
>
> To set the underline color (this is reserved and as far as I can tell not actually used for anything):
> 
> <ESC>[58...m
> This works exactly like the codes 38, 48 that are used to set foreground and background color respectively.
> 
> To reset the underline color (also previously reserved and unused):
> <ESC>[59m

In this initial step we currently don't support straight/double/curly/dotted/dashed nor colored underlines, but parse them and map them to normal underlines. Fixes https://github.com/termux/termux-packages/issues/20620, escape sequences showing up at the start of neovim. Future follow up work is actually respecting them when rendering, which is (at least IMHO) a nice touch when using code editors with support for it such as neovim.