### PR TITLE
Added: draft implementation of service_wake_show [UNTESTED]

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -150,6 +150,9 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
                     Logger.logDebug(LOG_TAG, "ACTION_WAKE_UNLOCK intent received");
                     actionReleaseWakeLock(true);
                     break;
+                case TERMUX_SERVICE.ACTION_WAKE_SHOW:
+                    Logger.logInfo(LOG_TAG, (mWakeLock != null) ? "1" : "0");
+                    break;
                 case TERMUX_SERVICE.ACTION_SERVICE_EXECUTE:
                     Logger.logDebug(LOG_TAG, "ACTION_SERVICE_EXECUTE intent received");
                     actionServiceExecute(intent);

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
@@ -990,6 +990,10 @@ public final class TermuxConstants {
             public static final String ACTION_WAKE_UNLOCK = TERMUX_PACKAGE_NAME + ".service_wake_unlock"; // Default: "com.termux.service_wake_unlock"
 
 
+            /** Intent action to show TERMUX_SERVICE wakelock state */
+            public static       String ACTION_WAKE_SHOW = TERMUX_PACKAGE_NAME + ".service_wake_show"; // Default: "com.termux.service_wake_show"
+
+
             /** Intent action to execute command with TERMUX_SERVICE */
             public static final String ACTION_SERVICE_EXECUTE = TERMUX_PACKAGE_NAME + ".service_execute"; // Default: "com.termux.service_execute"
 


### PR DESCRIPTION
This is just an untested mockup as I have almost no java experience and just wanted to get feedback whether this is a good approach. Reason for creating is the lack of a `termux-wake-show` (or similar, feel invited to comment) command to get the current wake-lock state..
