### PR TITLE
Added display of extra key "SPACE" as "␣" (U+2423)

### DIFF
--- a/termux-shared/src/main/java/com/termux/shared/termux/extrakeys/ExtraKeysConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/extrakeys/ExtraKeysConstants.java
@@ -94,6 +94,7 @@ public class ExtraKeysConstants {
             put("KEYBOARD", "⌨"); // U+2328 ⌨ KEYBOARD not well known but easy to understand
             put("PASTE", "⎘"); // U+2398
             put("SCROLL", "⇳"); // U+21F3
+            put("SPACE", "␣"); // U+2423
         }};
 
         public static final ExtraKeyDisplayMap LESS_KNOWN_CHARACTERS_DISPLAY = new ExtraKeyDisplayMap() {{


### PR DESCRIPTION
Added display of extra key "SPACE" as "␣" (U+2423). Referenced from https://en.wikipedia.org/wiki/Space_bar.