### PR TITLE
Fixed: termux-shared module use ndkVersion property uniformly

### DIFF
--- a/termux-shared/build.gradle
+++ b/termux-shared/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion project.properties.compileSdkVersion.toInteger()
+    ndkVersion = System.getenv("JITPACK_NDK_VERSION") ?: project.properties.ndkVersion
 
     dependencies {
         implementation "androidx.appcompat:appcompat:1.3.1"


### PR DESCRIPTION
If ndkVersion is not specified, the ndkversion corresponding to gradle will be used.
But other modules specify ndkVersion.
Finally, it is possible to use a different ndkversion.
