### PR TITLE
Update README.md to replace dead link and add a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ The main ones are the following.
 
 - [XTerm control sequences](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html)
 - [vt100.net](https://vt100.net/)
-- [Terminal codes (ANSI and terminfo equivalents)](https://wiki.bash-hackers.org/scripting/terminalcodes)
+- [Terminal codes (ANSI and terminfo equivalents)](https://archive.ph/20200706182357/https://wiki.bash-hackers.org/scripting/terminalcodes)
+- [ANSI escape code](https://en.wikipedia.org/wiki/ANSI_escape_code)
 
 ### Terminal emulators
 


### PR DESCRIPTION
Sometime around May 2023 (according to https://web.archive.org/web/2023*/https://wiki.bash-hackers.org/scripting/terminalcodes), bash-hackers.org started showing a parked page.