### PR TITLE
Added: Implement text scale disabling feature in terminal view

### DIFF
--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
@@ -227,8 +227,8 @@ public class TermuxTerminalViewClient extends TermuxTerminalViewClientBase {
     }
 
     @Override
-    public boolean isZoomScaleDisabled() {
-        return mActivity.getProperties().isZoomScaleDisabled();
+    public boolean isTerminalViewScalingDisabled() {
+        return mActivity.getProperties().isTerminalViewScalingDisabled();
     }
 
 

--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
@@ -226,6 +226,11 @@ public class TermuxTerminalViewClient extends TermuxTerminalViewClientBase {
         return mActivity.getTerminalToolbarViewPager() == null || mActivity.isTerminalViewSelected() || mActivity.getTerminalView().hasFocus();
     }
 
+    @Override
+    public boolean isZoomScaleDisabled() {
+        return mActivity.getProperties().isZoomScaleDisabled();
+    }
+
 
 
     @Override

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -187,7 +187,7 @@ public final class TerminalView extends View {
 
             @Override
             public boolean onScale(float focusX, float focusY, float scale) {
-                if (mEmulator == null || isSelectingText() || mClient.isZoomScaleDisabled()) return true;
+                if (mEmulator == null || isSelectingText() || mClient.isTerminalViewScalingDisabled()) return true;
                 mScaleFactor *= scale;
                 mScaleFactor = mClient.onScale(mScaleFactor);
                 return true;

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -187,7 +187,7 @@ public final class TerminalView extends View {
 
             @Override
             public boolean onScale(float focusX, float focusY, float scale) {
-                if (mEmulator == null || isSelectingText()) return true;
+                if (mEmulator == null || isSelectingText() || mClient.isZoomScaleDisabled()) return true;
                 mScaleFactor *= scale;
                 mScaleFactor = mClient.onScale(mScaleFactor);
                 return true;

--- a/terminal-view/src/main/java/com/termux/view/TerminalViewClient.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalViewClient.java
@@ -36,6 +36,7 @@ public interface TerminalViewClient {
 
     boolean isTerminalViewSelected();
 
+    boolean isZoomScaleDisabled();
 
 
     void copyModeChanged(boolean copyMode);

--- a/terminal-view/src/main/java/com/termux/view/TerminalViewClient.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalViewClient.java
@@ -36,7 +36,7 @@ public interface TerminalViewClient {
 
     boolean isTerminalViewSelected();
 
-    boolean isZoomScaleDisabled();
+    boolean isTerminalViewScalingDisabled();
 
 
     void copyModeChanged(boolean copyMode);

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxPropertyConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxPropertyConstants.java
@@ -82,7 +82,7 @@ import java.util.Set;
  *      - Add `KEY_DISABLE_FILE_SHARE_RECEIVER` and `KEY_DISABLE_FILE_VIEW_RECEIVER`.
  * 
  * - 0.19.0 (2025-01-23)
- *      - Add `KEY_DISABLE_ZOOM_SCALE`.
+ *      - Add `disable-terminal-view-scaling`.
  */
 
 /**
@@ -102,8 +102,8 @@ public final class TermuxPropertyConstants {
 
     /* boolean */
     
-    /** Defines the key for whether screen scaling are enabled. */
-    public static final String KEY_DISABLE_ZOOM_SCALE =  "disable-zoom-scale"; // Default: "disable-zoom-scale"
+    /** Defines the key for whether terminal view scaling are enabled. */
+    public static final String KEY_DISABLE_TERMINAL_VIEW_SCALING =  "disable-terminal-view-scaling"; // Default: "disable-terminal-view-scaling"
 
 
 
@@ -399,7 +399,7 @@ public final class TermuxPropertyConstants {
      * */
     public static final Set<String> TERMUX_APP_PROPERTIES_LIST = new HashSet<>(Arrays.asList(
         /* boolean */        
-        KEY_DISABLE_ZOOM_SCALE,
+        KEY_DISABLE_TERMINAL_VIEW_SCALING,
         KEY_DISABLE_FILE_SHARE_RECEIVER,
         KEY_DISABLE_FILE_VIEW_RECEIVER,
         KEY_DISABLE_HARDWARE_KEYBOARD_SHORTCUTS,
@@ -448,7 +448,7 @@ public final class TermuxPropertyConstants {
      * default: false
      */
     public static final Set<String> TERMUX_DEFAULT_FALSE_BOOLEAN_BEHAVIOUR_PROPERTIES_LIST = new HashSet<>(Arrays.asList(
-        KEY_DISABLE_ZOOM_SCALE,
+        KEY_DISABLE_TERMINAL_VIEW_SCALING,
         KEY_DISABLE_FILE_SHARE_RECEIVER,
         KEY_DISABLE_FILE_VIEW_RECEIVER,
         KEY_DISABLE_HARDWARE_KEYBOARD_SHORTCUTS,

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxPropertyConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxPropertyConstants.java
@@ -80,6 +80,9 @@ import java.util.Set;
  *
  * - 0.18.0 (2022-06-13)
  *      - Add `KEY_DISABLE_FILE_SHARE_RECEIVER` and `KEY_DISABLE_FILE_VIEW_RECEIVER`.
+ * 
+ * - 0.19.0 (2025-01-23)
+ *      - Add `KEY_DISABLE_ZOOM_SCALE`.
  */
 
 /**
@@ -98,6 +101,11 @@ public final class TermuxPropertyConstants {
     private static final String LOG_TAG = "TermuxPropertyConstants";
 
     /* boolean */
+    
+    /** Defines the key for whether screen scaling are enabled. */
+    public static final String KEY_DISABLE_ZOOM_SCALE =  "disable-zoom-scale"; // Default: "disable-zoom-scale"
+
+
 
     /** Defines the key for whether file share receiver of the app is enabled. */
     public static final String KEY_DISABLE_FILE_SHARE_RECEIVER =  "disable-file-share-receiver"; // Default: "disable-file-share-receiver"
@@ -390,7 +398,8 @@ public final class TermuxPropertyConstants {
      * Setting this to {@code null} will make {@link SharedProperties} throw an exception.
      * */
     public static final Set<String> TERMUX_APP_PROPERTIES_LIST = new HashSet<>(Arrays.asList(
-        /* boolean */
+        /* boolean */        
+        KEY_DISABLE_ZOOM_SCALE,
         KEY_DISABLE_FILE_SHARE_RECEIVER,
         KEY_DISABLE_FILE_VIEW_RECEIVER,
         KEY_DISABLE_HARDWARE_KEYBOARD_SHORTCUTS,
@@ -439,6 +448,7 @@ public final class TermuxPropertyConstants {
      * default: false
      */
     public static final Set<String> TERMUX_DEFAULT_FALSE_BOOLEAN_BEHAVIOUR_PROPERTIES_LIST = new HashSet<>(Arrays.asList(
+        KEY_DISABLE_ZOOM_SCALE,
         KEY_DISABLE_FILE_SHARE_RECEIVER,
         KEY_DISABLE_FILE_VIEW_RECEIVER,
         KEY_DISABLE_HARDWARE_KEYBOARD_SHORTCUTS,

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
@@ -573,6 +573,9 @@ public abstract class TermuxSharedProperties {
 
 
 
+    public boolean isZoomScaleDisabled() {
+        return (boolean) getInternalPropertyValue(TermuxPropertyConstants.KEY_DISABLE_ZOOM_SCALE, true);
+    }
 
     public boolean shouldAllowExternalApps() {
         return (boolean) getInternalPropertyValue(TermuxConstants.PROP_ALLOW_EXTERNAL_APPS, true);

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
@@ -573,8 +573,8 @@ public abstract class TermuxSharedProperties {
 
 
 
-    public boolean isZoomScaleDisabled() {
-        return (boolean) getInternalPropertyValue(TermuxPropertyConstants.KEY_DISABLE_ZOOM_SCALE, true);
+    public boolean isTerminalViewScalingDisabled() {
+        return (boolean) getInternalPropertyValue(TermuxPropertyConstants.KEY_DISABLE_TERMINAL_VIEW_SCALING, true);
     }
 
     public boolean shouldAllowExternalApps() {

--- a/termux-shared/src/main/java/com/termux/shared/termux/terminal/TermuxTerminalViewClientBase.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/terminal/TermuxTerminalViewClientBase.java
@@ -13,7 +13,7 @@ public class TermuxTerminalViewClientBase implements TerminalViewClient {
     }
 
     @Override
-    public boolean isZoomScaleDisabled() {
+    public boolean isTerminalViewScalingDisabled() {
         return false;
     }
     

--- a/termux-shared/src/main/java/com/termux/shared/termux/terminal/TermuxTerminalViewClientBase.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/terminal/TermuxTerminalViewClientBase.java
@@ -13,6 +13,11 @@ public class TermuxTerminalViewClientBase implements TerminalViewClient {
     }
 
     @Override
+    public boolean isZoomScaleDisabled() {
+        return false;
+    }
+    
+    @Override
     public float onScale(float scale) {
         return 1.0f;
     }


### PR DESCRIPTION
This pull request introduces a new feature to disable terminal view scaling and includes several changes across different files to implement and support this feature.

New feature implementation:

* [`app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java`](diffhunk://#diff-aefe2c0473dc60d55440d6bf245acf86ed60c08fad6a90031f0948ea395e8cdaR229-R233): Added the method `isTerminalViewScalingDisabled` to check if terminal view scaling is disabled.
* [`terminal-view/src/main/java/com/termux/view/TerminalView.java`](diffhunk://#diff-380d9ad0fe475639356f0367b3050291e5bd4e8c8eb9d76a73096ddc44315aa1L190-R190): Modified the `onScale` method to respect the new `isTerminalViewScalingDisabled` check.
* [`terminal-view/src/main/java/com/termux/view/TerminalViewClient.java`](diffhunk://#diff-7751b2b37bb1e1bf3f8b5020e531ca3fb5fcce51f233167a96309b5aad7a5a20R39): Added the `isTerminalViewScalingDisabled` method to the `TerminalViewClient` interface.

Support for new feature in properties:

* [`termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxPropertyConstants.java`](diffhunk://#diff-7c1dac0096663ef3165b9d4521b939670f72a92fb21d4915a8bc205d19754145R83-R85): Added the key `KEY_DISABLE_TERMINAL_VIEW_SCALING` and updated relevant property lists to include this new key. [[1]](diffhunk://#diff-7c1dac0096663ef3165b9d4521b939670f72a92fb21d4915a8bc205d19754145R83-R85) [[2]](diffhunk://#diff-7c1dac0096663ef3165b9d4521b939670f72a92fb21d4915a8bc205d19754145R105-R109) [[3]](diffhunk://#diff-7c1dac0096663ef3165b9d4521b939670f72a92fb21d4915a8bc205d19754145R402) [[4]](diffhunk://#diff-7c1dac0096663ef3165b9d4521b939670f72a92fb21d4915a8bc205d19754145R451)
* [`termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java`](diffhunk://#diff-29738315beee13a7aae8558437f0a0eb2c27280171573a0edef66826a1815a7bR576-R578): Added the method `isTerminalViewScalingDisabled` to retrieve the property value.
* [`termux-shared/src/main/java/com/termux/shared/termux/terminal/TermuxTerminalViewClientBase.java`](diffhunk://#diff-6cda577f7fbbd18771b6bf1a4e519d734e92649a71f26c7bb08c5fb08ae03c4fR15-R19): Implemented the `isTerminalViewScalingDisabled` method to return a default value.