### PR TITLE
fix: ensure session list updates run on UI thread

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -856,7 +856,8 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
 
 
     public void termuxSessionListNotifyUpdated() {
-        mTermuxSessionListViewController.notifyDataSetChanged();
+      if (mTermuxSessionListViewController == null) return;
+      runOnUiThread(() -> mTermuxSessionListViewController.notifyDataSetChanged());
     }
 
     public boolean isVisible() {
@@ -1007,6 +1008,11 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
     public static Intent newInstance(@NonNull final Context context) {
         Intent intent = new Intent(context, TermuxActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        return intent;
+    }
+
+}
+ntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         return intent;
     }
 


### PR DESCRIPTION
this fixes a crash (`IllegalStateException`) caused by
`notifyDataSetChanged()` being invoked from non-ui threads when
termuxservice modifies the session list.

changes:
- Wrap `notifyDataSetChanged()` inside `runOnUiThread()` in
  `TermuxActivity.termuxSessionListNotifyUpdated()`.
- Add null-check for `mTermuxSessionListViewController` to
  prevent potential NPEs.
- Verified that no other direct calls to
  `notifyDataSetChanged()` exist outside TermuxActivity,
  ensuring consistent session list refresh behavior.

Fixes: #4725