### PR TITLE
Added(terminal): add separate italic, bold and boldItalic font files

### DIFF
--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
@@ -31,6 +31,7 @@ import com.termux.terminal.TerminalColors;
 import com.termux.terminal.TerminalSession;
 import com.termux.terminal.TerminalSessionClient;
 import com.termux.terminal.TextStyle;
+import com.termux.view.TerminalRenderer;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -494,7 +495,6 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
     public void checkForFontAndColors() {
         try {
             File colorsFile = TermuxConstants.TERMUX_COLOR_PROPERTIES_FILE;
-            File fontFile = TermuxConstants.TERMUX_FONT_FILE;
 
             final Properties props = new Properties();
             if (colorsFile.isFile()) {
@@ -510,10 +510,19 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
             }
             updateBackgroundColor();
 
-            final Typeface newTypeface = (fontFile.exists() && fontFile.length() > 0) ? Typeface.createFromFile(fontFile) : Typeface.MONOSPACE;
-            mActivity.getTerminalView().setTypeface(newTypeface);
+            setTypeface(TermuxConstants.TERMUX_FONT_FILE, TerminalRenderer.TypefaceStyle.NORMAL);
+            setTypeface(TermuxConstants.TERMUX_ITALIC_FONT_FILE, TerminalRenderer.TypefaceStyle.ITALIC);
+            setTypeface(TermuxConstants.TERMUX_BOLD_FONT_FILE, TerminalRenderer.TypefaceStyle.BOLD);
+            setTypeface(TermuxConstants.TERMUX_BOLD_ITALIC_FONT_FILE, TerminalRenderer.TypefaceStyle.BOLD_ITALIC);
         } catch (Exception e) {
             Logger.logStackTraceWithMessage(LOG_TAG, "Error in checkForFontAndColors()", e);
+        }
+    }
+
+    private void setTypeface(File fontFile, TerminalRenderer.TypefaceStyle style) {
+        if (fontFile.exists() && fontFile.length() > 0) {
+            final Typeface newTypeface = Typeface.createFromFile(fontFile);
+            mActivity.getTerminalView().setTypeface(newTypeface, style);
         }
     }
 

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -178,8 +178,8 @@ public final class TerminalView extends View {
                 } else {
                     scrolledWithFinger = true;
                     distanceY += mScrollRemainder;
-                    int deltaRows = (int) (distanceY / mRenderer.mFontLineSpacing);
-                    mScrollRemainder = distanceY - deltaRows * mRenderer.mFontLineSpacing;
+                    int deltaRows = (int) (distanceY / mRenderer.getFontLineSpacing());
+                    mScrollRemainder = distanceY - deltaRows * mRenderer.getFontLineSpacing();
                     doScroll(e, deltaRows);
                 }
                 return true;
@@ -512,12 +512,17 @@ public final class TerminalView extends View {
      * @param textSize the new font size, in density-independent pixels.
      */
     public void setTextSize(int textSize) {
-        mRenderer = new TerminalRenderer(textSize, mRenderer == null ? Typeface.MONOSPACE : mRenderer.mTypeface);
+        if (mRenderer == null) {
+            mRenderer = new TerminalRenderer(textSize);
+            mRenderer.setTypeface(Typeface.MONOSPACE, TerminalRenderer.TypefaceStyle.NORMAL);
+        } else {
+            mRenderer.setTextSize(textSize);
+        }
         updateSize();
     }
 
-    public void setTypeface(Typeface newTypeface) {
-        mRenderer = new TerminalRenderer(mRenderer.mTextSize, newTypeface);
+    public void setTypeface(Typeface newTypeface, TerminalRenderer.TypefaceStyle style) {
+        mRenderer.setTypeface(newTypeface, style);
         updateSize();
         invalidate();
     }
@@ -544,8 +549,8 @@ public final class TerminalView extends View {
      * @return Array with the column and row.
      */
     public int[] getColumnAndRow(MotionEvent event, boolean relativeToScroll) {
-        int column = (int) (event.getX() / mRenderer.mFontWidth);
-        int row = (int) ((event.getY() - mRenderer.mFontLineSpacingAndAscent) / mRenderer.mFontLineSpacing);
+        int column = (int) (event.getX() / mRenderer.getFontWidth());
+        int row = (int) ((event.getY() - mRenderer.getFontLineSpacingAndAscent()) / mRenderer.getFontLineSpacing());
         if (relativeToScroll) {
             row += mTopRow;
         }
@@ -985,8 +990,8 @@ public final class TerminalView extends View {
         if (viewWidth == 0 || viewHeight == 0 || mTermSession == null) return;
 
         // Set to 80 and 24 if you want to enable vttest.
-        int newColumns = Math.max(4, (int) (viewWidth / mRenderer.mFontWidth));
-        int newRows = Math.max(4, (viewHeight - mRenderer.mFontLineSpacingAndAscent) / mRenderer.mFontLineSpacing);
+        int newColumns = Math.max(4, (int) (viewWidth / mRenderer.getFontWidth()));
+        int newRows = Math.max(4, (viewHeight - mRenderer.getFontLineSpacingAndAscent()) / mRenderer.getFontLineSpacing());
 
         if (mEmulator == null || (newColumns != mEmulator.mColumns || newRows != mEmulator.mRows)) {
             mTermSession.updateSize(newColumns, newRows, (int) mRenderer.getFontWidth(), mRenderer.getFontLineSpacing());
@@ -1030,22 +1035,22 @@ public final class TerminalView extends View {
     }
 
     public int getCursorX(float x) {
-        return (int) (x / mRenderer.mFontWidth);
+        return (int) (x / mRenderer.getFontWidth());
     }
 
     public int getCursorY(float y) {
-        return (int) (((y - 40) / mRenderer.mFontLineSpacing) + mTopRow);
+        return (int) (((y - 40) / mRenderer.getFontLineSpacing()) + mTopRow);
     }
 
     public int getPointX(int cx) {
         if (cx > mEmulator.mColumns) {
             cx = mEmulator.mColumns;
         }
-        return Math.round(cx * mRenderer.mFontWidth);
+        return Math.round(cx * mRenderer.getFontWidth());
     }
 
     public int getPointY(int cy) {
-        return Math.round((cy - mTopRow) * mRenderer.mFontLineSpacing);
+        return Math.round((cy - mTopRow) * mRenderer.getFontLineSpacing());
     }
 
     public int getTopRow() {

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
@@ -771,6 +771,18 @@ public final class TermuxConstants {
     public static final String TERMUX_FONT_FILE_PATH = TERMUX_DATA_HOME_DIR_PATH + "/font.ttf"; // Default: "/data/data/com.termux/files/home/.termux/font.ttf"
     /** Termux app and Termux:Styling font.ttf file */
     public static final File TERMUX_FONT_FILE = new File(TERMUX_FONT_FILE_PATH);
+    /** Termux app and Termux:Styling font-italic.ttf file path */
+    public static final String TERMUX_ITALIC_FONT_FILE_PATH = TERMUX_DATA_HOME_DIR_PATH + "/font-italic.ttf"; // Default: "/data/data/com.termux/files/home/.termux/font-italic.ttf"
+    /** Termux app and Termux:Styling font-italic.ttf file */
+    public static final File TERMUX_ITALIC_FONT_FILE = new File(TERMUX_ITALIC_FONT_FILE_PATH);
+    /** Termux app and Termux:Styling font-bold.ttf file path */
+    public static final String TERMUX_BOLD_FONT_FILE_PATH = TERMUX_DATA_HOME_DIR_PATH + "/font-bold.ttf"; // Default: "/data/data/com.termux/files/home/.termux/font-bold.ttf"
+    /** Termux app and Termux:Styling font-bold.ttf file */
+    public static final File TERMUX_BOLD_FONT_FILE = new File(TERMUX_BOLD_FONT_FILE_PATH);
+    /** Termux app and Termux:Styling font-bold-italic.ttf file path */
+    public static final String TERMUX_BOLD_ITALIC_FONT_FILE_PATH = TERMUX_DATA_HOME_DIR_PATH + "/font-bold-italic.ttf"; // Default: "/data/data/com.termux/files/home/.termux/font-bold-italic.ttf"
+    /** Termux app and Termux:Styling font-bold-italic.ttf file */
+    public static final File TERMUX_BOLD_ITALIC_FONT_FILE = new File(TERMUX_BOLD_ITALIC_FONT_FILE_PATH);
 
 
     /** Termux app and plugins crash log file path */


### PR DESCRIPTION
Add optional usage of `font-italic.ttf` `font-bold.ttf` and `font-bold-italic.ttf` font files.

- Behaviour stays the same as before for italic and bold text if `font-italic.ttf` and/or `font-bold.ttf` is not supplied/empty.
- If there is no `font-bold-italic.ttf`, the renderer will try to fallback to the supplied italic font (and make it fake bold) or the supplied bold font(and skew it) or the normal font(and skew + fake bold) in that order of priority.

Closes #711 