### PR TITLE
Fixed: Update gradle wrapper validation in CI

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@5


### PR DESCRIPTION
Replace `gradle/wrapper-validation-action@v3` with `gradle/actions/wrapper-validation@5` which should fix the error seen e.g. [here](https://github.com/termux/termux-app/actions/runs/20685857619/job/59386383274):

> Error: The action gradle/actions/wrapper-validation@v3.5.0 is not allowed in termux/termux-app because all actions must be from a repository owned by termux, created by GitHub, or match one of the patterns: gradle/actions/dependency-submission@*, gradle/wrapper-validation-action@v*.