### PR TITLE
Fixed: Allow language switch key on external keyboards

### DIFF
--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -782,6 +782,8 @@ public final class TerminalView extends View {
         } else if (event.getAction() == KeyEvent.ACTION_MULTIPLE && keyCode == KeyEvent.KEYCODE_UNKNOWN) {
             mTermSession.write(event.getCharacters());
             return true;
+        } else if (keyCode == KeyEvent.KEYCODE_LANGUAGE_SWITCH) {
+            return super.onKeyDown(keyCode, event);
         }
 
         final int metaState = event.getMetaState();


### PR DESCRIPTION
Pass KEYCODE_LANGUAGE_SWITCH events to the system handler instead of consuming them in Termux, allowing keyboard layout switching to work on external keyboards.

used exact code in https://github.com/termux/termux-app/issues/4133#issuecomment-2409971399

Fixes #4133