### PR TITLE
Fixed: Correct publication of Maven libraries after update of Gradle to 9.2.1

### DIFF
--- a/terminal-emulator/build.gradle
+++ b/terminal-emulator/build.gradle
@@ -43,6 +43,14 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
+
+    publishing {
+        multipleVariants {
+            withSourcesJar()
+            withJavadocJar()
+            allVariants()
+        }
+    }
 }
 
 tasks.withType(Test) {
@@ -66,7 +74,7 @@ afterEvaluate {
         publications {
             // Creates a Maven publication called "release".
             release(MavenPublication) {
-                from components.findByName('release')
+                from components.default
                 groupId = 'com.termux'
                 artifactId = 'terminal-emulator'
                 version = '0.118.0'

--- a/terminal-view/build.gradle
+++ b/terminal-view/build.gradle
@@ -27,6 +27,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    publishing {
+        multipleVariants {
+            withSourcesJar()
+            withJavadocJar()
+            allVariants()
+        }
+    }
 }
 
 dependencies {
@@ -43,7 +51,7 @@ afterEvaluate {
         publications {
             // Creates a Maven publication called "release".
             release(MavenPublication) {
-                from components.findByName('release')
+                from components.default
                 groupId = 'com.termux'
                 artifactId = 'terminal-view'
                 version = '0.118.0'

--- a/termux-shared/build.gradle
+++ b/termux-shared/build.gradle
@@ -63,6 +63,14 @@ android {
             path file('src/main/cpp/Android.mk')
         }
     }
+
+    publishing {
+        multipleVariants {
+            withSourcesJar()
+            withJavadocJar()
+            allVariants()
+        }
+    }
 }
 
 dependencies {
@@ -81,7 +89,7 @@ afterEvaluate {
         publications {
             // Creates a Maven publication called "release".
             release(MavenPublication) {
-                from components.findByName('release')
+                from components.default
                 groupId = 'com.termux'
                 artifactId = 'termux-shared'
                 version = '0.118.0'


### PR DESCRIPTION
- After https://github.com/termux/termux-app/pull/3619, unfortunately this error began to occur when one attempts to use the [Publication to Maven Local guide](https://github.com/termux/termux-app/wiki/Termux-Libraries#forking-and-local-development) to compile all Termux APKs entirely from source, which previously worked:

```
> Task :app:processDebugResources FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processDebugResources'.
> A failure occurred while executing com.android.build.gradle.internal.res.LinkApplicationAndroidResourcesTask$TaskAction
   > Android resource linking failed
     ERROR: /home/tacokoneko/code/termux/termux-generator/termux-apps-main/termux-api/app/src/main/AndroidManifest.xml:72:9-76:20: AAPT: error: resource style/Theme.BaseActivity.DayNight.NoActionBar (aka com.termux.api:style/Theme.BaseActivity.DayNight.NoActionBar) not found.

     ERROR: /home/tacokoneko/code/termux/termux-generator/termux-apps-main/termux-api/app/src/main/AndroidManifest.xml:88:9-93:20: AAPT: error: resource style/Theme.BaseActivity.DayNight.NoActionBar (aka com.termux.api:style/Theme.BaseActivity.DayNight.NoActionBar) not found.

     ERROR: /home/tacokoneko/code/termux/termux-generator/termux-apps-main/termux-api/app/build/intermediates/packaged_manifests/debug/processDebugManifestForPackage/AndroidManifest.xml:183: AAPT: error: resource style/Theme.MarkdownViewActivity.DayNight (aka three.termux.api:style/Theme.MarkdownViewActivity.DayNight) not found.
```

- This PR fixes that error by using `components.default` in the `publications` block instead of `components.findByName('release')` and adding a `publishing` block to the `android` section of the `build.gradle` of each affected library, in accordance with https://developer.android.com/reference/tools/gradle-api/9.1/com/android/build/api/dsl/PublishingOptions and https://stackoverflow.com/a/71366104. `components.release` no longer works, but testing indicates that `components.default` works.