### PR TITLE
Fixed: Revert `desugar_jdk_libs` back to 1.1.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,7 +148,7 @@ android {
 dependencies {
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.robolectric:robolectric:4.10"
-    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.2"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"
 }
 
 task versionName {

--- a/termux-shared/build.gradle
+++ b/termux-shared/build.gradle
@@ -76,7 +76,7 @@ android {
 dependencies {
     testImplementation "junit:junit:4.13.2"
     androidTestImplementation "androidx.test.ext:junit:1.1.5"
-    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.2"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"
 }
 
 task sourceJar(type: Jar) {


### PR DESCRIPTION
- This is necessary because `desugar_jdk_libs` version 2.1.2 adds new `java.nio.file` APIs that are untested, and additionally, `java.nio.file` APIs are known to be broken, so will be removed from Termux in the future rather than being bumped. More information here: https://github.com/termux/termux-app/pull/3619#discussion_r2680770189

- This is necessary to prevent errors like this while using the [local Maven repository guide](https://github.com/termux/termux-app/wiki/Termux-Libraries#forking-and-local-development) to build reverse dependencies like Termux:API after https://github.com/termux/termux-app/pull/3619

```
1.  Dependency 'com.termux:termux-shared:0.118.0' requires desugar_jdk_libs version to be
           2.1.2 or above for :app, which is currently 1.1.5
```

- Partially reverts https://github.com/termux/termux-app/pull/3619