### PR TITLE
feat: multi window support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
             android:exported="true"
             android:configChanges="orientation|screenSize|smallestScreenSize|density|screenLayout|keyboard|keyboardHidden|navigation"
             android:label="@string/application_name"
-            android:launchMode="singleTask"
+            android:launchMode="standard"
             android:resizeableActivity="true"
             android:theme="@style/Theme.TermuxActivity.DayNight.NoActionBar"
             tools:targetApi="n">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.REORDER_TASKS" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
 
     <application

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -415,9 +415,9 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
         }
     }
 
-    /** Add a new window in multi-window mode */
+    /** Add a new window */
     public void addNewWindow() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isInMultiWindowMode()) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             Intent intent = new Intent(this, TermuxActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_LAUNCH_ADJACENT |
                            Intent.FLAG_ACTIVITY_NEW_TASK |

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -370,9 +370,14 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
                 mTermuxService.resetSessionClient(currentSession);
             }
             mTerminalView.detachSession();
+
+            // Notify other windows that session attachment state changed
+            mTermuxService.notifyAllSessionListsUpdated();
         }
 
         if (mTermuxService != null) {
+            // Remove this activity's client from the service's set
+            mTermuxService.removeTermuxTerminalSessionClient(mTermuxTerminalSessionActivityClient);
             mTermuxService = null;
         }
 

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -281,11 +281,6 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
         // Send the {@link TermuxConstants#BROADCAST_TERMUX_OPENED} broadcast to notify apps that Termux
         // app has been opened.
         TermuxUtils.sendTermuxOpenedBroadcast(this);
-
-        // Set initial multi-window UI state
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            onMultiWindowModeChanged(isInMultiWindowMode());
-        }
     }
 
     @Override
@@ -401,18 +396,6 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
     public void onMultiWindowModeChanged(boolean isInMultiWindowMode) {
         super.onMultiWindowModeChanged(isInMultiWindowMode);
         Logger.logDebug(LOG_TAG, "onMultiWindowModeChanged: " + isInMultiWindowMode);
-
-        // Show or hide the new window button based on multi-window mode
-        View newWindowButton = findViewById(R.id.new_window_button);
-        if (newWindowButton != null) {
-            newWindowButton.setVisibility(isInMultiWindowMode ? View.VISIBLE : View.GONE);
-        }
-
-        // Change drawer buttons orientation to vertical in multi-window mode to save horizontal space
-        LinearLayout drawerButtons = findViewById(R.id.drawer_buttons);
-        if (drawerButtons != null) {
-            drawerButtons.setOrientation(isInMultiWindowMode ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL);
-        }
     }
 
     /** Add a new window */
@@ -665,12 +648,14 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
         View newWindowButton = findViewById(R.id.new_window_button);
         if (newWindowButton != null) {
             newWindowButton.setOnClickListener(v -> addNewWindow());
-            // Initially hidden, shown only in multi-window mode
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isInMultiWindowMode()) {
-                newWindowButton.setVisibility(View.VISIBLE);
-            } else {
-                newWindowButton.setVisibility(View.GONE);
-            }
+            // Show if multi-window API is available (N+)
+            newWindowButton.setVisibility(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ? View.VISIBLE : View.GONE);
+        }
+
+        // Use vertical orientation for drawer buttons if multi-window is available
+        LinearLayout drawerButtons = findViewById(R.id.drawer_buttons);
+        if (drawerButtons != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            drawerButtons.setOrientation(LinearLayout.VERTICAL);
         }
     }
 

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -456,11 +456,18 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
             // then the original intent will be re-delivered, resulting in a new session being re-added
             // each time.
             if (!mIsActivityRecreated && intent != null && Intent.ACTION_RUN.equals(intent.getAction())) {
-                // Android 7.1 app shortcut from res/xml/shortcuts.xml.
-                boolean isFailSafe = intent.getBooleanExtra(TERMUX_ACTIVITY.EXTRA_FAILSAFE_SESSION, false);
-                mTermuxTerminalSessionActivityClient.addNewSession(isFailSafe, null);
-            } else {
-                // In multi-window mode, try to atomically claim first unattached session
+                if (intent.getBooleanExtra(TERMUX_ACTIVITY.EXTRA_NEW_WINDOW, false)) {
+                    // Android 7.1 app shortcut: open a new window
+                    addNewWindow();
+                } else {
+                    // Android 7.1 app shortcut from res/xml/shortcuts.xml.
+                    boolean isFailSafe = intent.getBooleanExtra(TERMUX_ACTIVITY.EXTRA_FAILSAFE_SESSION, false);
+                    mTermuxTerminalSessionActivityClient.addNewSession(isFailSafe, null);
+                }
+            }
+
+            // Ensure this activity is attached to a session
+            if (getCurrentSession() == null) {
                 TerminalSession sessionToAttach = mTermuxService.claimFirstUnattachedSession(mActivityId);
                 if (sessionToAttach != null) {
                     mTermuxTerminalSessionActivityClient.setCurrentSession(sessionToAttach);

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -826,6 +826,31 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
     }
 
     /**
+     * Bring the activity that owns a session to the foreground.
+     * @param session The session whose owning activity should be focused
+     * @return true if the activity was found and brought to front
+     */
+    @SuppressLint("MissingPermission")
+    public synchronized boolean focusActivityForSession(TerminalSession session) {
+        if (session == null) return false;
+        Integer ownerId = mSessionAttachments.get(session.mHandle);
+        if (ownerId == null) return false;
+
+        for (TermuxTerminalSessionActivityClient client : mActivityClients) {
+            TermuxActivity activity = client.getActivity();
+            if (activity != null && activity.getActivityId() == ownerId) {
+                // Bring the activity's task to front
+                android.app.ActivityManager am = (android.app.ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
+                if (am != null) {
+                    am.moveTaskToFront(activity.getTaskId(), 0);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Attempt to attach a session to an activity. Fails if already attached elsewhere.
      * @param session The session to attach
      * @param activityId The activity ID claiming the session

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -906,6 +906,18 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
         return mShellManager.mTermuxSessions.isEmpty() ? null : mShellManager.mTermuxSessions.get(mShellManager.mTermuxSessions.size() - 1);
     }
 
+    /** Get the first session that is not attached to any window. Used for multi-window support. */
+    @Nullable
+    public synchronized TerminalSession getFirstUnattachedSession() {
+        for (int i = 0; i < mShellManager.mTermuxSessions.size(); i++) {
+            TerminalSession session = mShellManager.mTermuxSessions.get(i).getTerminalSession();
+            if (!session.mAttached) {
+                return session;
+            }
+        }
+        return null;
+    }
+
     public synchronized int getIndexOfSession(TerminalSession terminalSession) {
         if (terminalSession == null) return -1;
 

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -50,7 +50,9 @@ import com.termux.terminal.TerminalSession;
 import com.termux.terminal.TerminalSessionClient;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A service holding a list of {@link TermuxSession} in {@link TermuxShellManager#mTermuxSessions} and background {@link AppShell}
@@ -77,11 +79,12 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
     private final Handler mHandler = new Handler();
 
 
-    /** The full implementation of the {@link TerminalSessionClient} interface to be used by {@link TerminalSession}
-     * that holds activity references for activity related functions.
-     * Note that the service may often outlive the activity, so need to clear this reference.
+    /** The full implementations of the {@link TerminalSessionClient} interface to be used by {@link TerminalSession}
+     * that hold activity references for activity related functions. In multi-window mode, multiple
+     * activities may be bound simultaneously. Note that the service may often outlive the activities,
+     * so need to clear these references when activities are destroyed.
      */
-    private TermuxTerminalSessionActivityClient mTermuxTerminalSessionActivityClient;
+    private final Set<TermuxTerminalSessionActivityClient> mActivityClients = new HashSet<>();
 
     /** The basic implementation of the {@link TerminalSessionClient} interface to be used by {@link TerminalSession}
      * that does not hold activity references and only a service reference.
@@ -195,7 +198,7 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
         // Since we cannot rely on {@link TermuxActivity.onDestroy()} to always complete,
         // we unset clients here as well if it failed, so that we do not leave service and session
         // clients with references to the activity.
-        if (mTermuxTerminalSessionActivityClient != null)
+        if (!mActivityClients.isEmpty())
             unsetTermuxTerminalSessionClient();
         return false;
     }
@@ -612,10 +615,8 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
         if (executionCommand.isPluginExecutionCommand)
             mShellManager.mPendingPluginExecutionCommands.remove(executionCommand);
 
-        // Notify {@link TermuxSessionsListViewController} that sessions list has been updated if
-        // activity in is foreground
-        if (mTermuxTerminalSessionActivityClient != null)
-            mTermuxTerminalSessionActivityClient.termuxSessionListNotifyUpdated();
+        // Notify all activities that sessions list has been updated
+        notifyAllSessionListsUpdated();
 
         updateNotification();
 
@@ -649,10 +650,8 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
 
             mShellManager.mTermuxSessions.remove(termuxSession);
 
-            // Notify {@link TermuxSessionsListViewController} that sessions list has been updated if
-            // activity in is foreground
-            if (mTermuxTerminalSessionActivityClient != null)
-                mTermuxTerminalSessionActivityClient.termuxSessionListNotifyUpdated();
+            // Notify all activities that sessions list has been updated
+            notifyAllSessionListsUpdated();
         }
 
         updateNotification();
@@ -687,8 +686,8 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
         switch (sessionAction) {
             case TERMUX_SERVICE.VALUE_EXTRA_SESSION_ACTION_SWITCH_TO_NEW_SESSION_AND_OPEN_ACTIVITY:
                 setCurrentStoredTerminalSession(newTerminalSession);
-                if (mTermuxTerminalSessionActivityClient != null)
-                    mTermuxTerminalSessionActivityClient.setCurrentSession(newTerminalSession);
+                if (!mActivityClients.isEmpty())
+                    mActivityClients.iterator().next().setCurrentSession(newTerminalSession);
                 startTermuxActivity();
                 break;
             case TERMUX_SERVICE.VALUE_EXTRA_SESSION_ACTION_KEEP_CURRENT_SESSION_AND_OPEN_ACTIVITY:
@@ -698,8 +697,8 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
                 break;
             case TERMUX_SERVICE.VALUE_EXTRA_SESSION_ACTION_SWITCH_TO_NEW_SESSION_AND_DONT_OPEN_ACTIVITY:
                 setCurrentStoredTerminalSession(newTerminalSession);
-                if (mTermuxTerminalSessionActivityClient != null)
-                    mTermuxTerminalSessionActivityClient.setCurrentSession(newTerminalSession);
+                if (!mActivityClients.isEmpty())
+                    mActivityClients.iterator().next().setCurrentSession(newTerminalSession);
                 break;
             case TERMUX_SERVICE.VALUE_EXTRA_SESSION_ACTION_KEEP_CURRENT_SESSION_AND_DONT_OPEN_ACTIVITY:
                 if (getTermuxSessionsSize() == 1)
@@ -731,38 +730,42 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
 
 
 
-    /** If {@link TermuxActivity} has not bound to the {@link TermuxService} yet or is destroyed, then
+    /** If no {@link TermuxActivity} has bound to the {@link TermuxService} yet or all are destroyed, then
      * interface functions requiring the activity should not be available to the terminal sessions,
      * so we just return the {@link #mTermuxTerminalSessionServiceClient}. Once {@link TermuxActivity} bind
-     * callback is received, it should call {@link #setTermuxTerminalSessionClient} to set the
-     * {@link TermuxService#mTermuxTerminalSessionActivityClient} so that further terminal sessions are directly
-     * passed the {@link TermuxTerminalSessionActivityClient} object which fully implements the
+     * callback is received, it should call {@link #setTermuxTerminalSessionClient} to add its client
+     * to {@link TermuxService#mActivityClients} so that further terminal sessions are directly
+     * passed a {@link TermuxTerminalSessionActivityClient} object which fully implements the
      * {@link TerminalSessionClient} interface.
      *
-     * @return Returns the {@link TermuxTerminalSessionActivityClient} if {@link TermuxActivity} has bound with
-     * {@link TermuxService}, otherwise {@link TermuxTerminalSessionServiceClient}.
+     * @return Returns the first available {@link TermuxTerminalSessionActivityClient} if any {@link TermuxActivity}
+     * has bound with {@link TermuxService}, otherwise {@link TermuxTerminalSessionServiceClient}.
      */
     public synchronized TermuxTerminalSessionClientBase getTermuxTerminalSessionClient() {
-        if (mTermuxTerminalSessionActivityClient != null)
-            return mTermuxTerminalSessionActivityClient;
+        if (!mActivityClients.isEmpty())
+            return mActivityClients.iterator().next();
         else
             return mTermuxTerminalSessionServiceClient;
     }
 
-    /** This should be called when {@link TermuxActivity#onServiceConnected} is called to set the
-     * {@link TermuxService#mTermuxTerminalSessionActivityClient} variable and update the {@link TerminalSession}
-     * and {@link TerminalEmulator} clients in case they were passed {@link TermuxTerminalSessionServiceClient}
-     * earlier.
+    /** This should be called when {@link TermuxActivity#onServiceConnected} is called to add
+     * the activity's client to {@link TermuxService#mActivityClients}. In multi-window mode,
+     * multiple activities may be bound simultaneously.
      *
      * @param termuxTerminalSessionActivityClient The {@link TermuxTerminalSessionActivityClient} object that fully
      * implements the {@link TerminalSessionClient} interface.
      */
     public synchronized void setTermuxTerminalSessionClient(TermuxTerminalSessionActivityClient termuxTerminalSessionActivityClient) {
-        mTermuxTerminalSessionActivityClient = termuxTerminalSessionActivityClient;
+        mActivityClients.add(termuxTerminalSessionActivityClient);
 
         // Don't update all sessions' clients here - in multi-window mode, each activity
         // should only set the client for its own attached session. The client is set
         // when setCurrentSession() is called in TermuxTerminalSessionActivityClient.
+    }
+
+    /** Remove an activity client when its activity is destroyed. */
+    public synchronized void removeTermuxTerminalSessionClient(TermuxTerminalSessionActivityClient client) {
+        mActivityClients.remove(client);
     }
 
     /** This should be called when {@link TermuxActivity} has been destroyed and in {@link #onUnbind(Intent)}
@@ -773,7 +776,7 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
         for (int i = 0; i < mShellManager.mTermuxSessions.size(); i++)
             mShellManager.mTermuxSessions.get(i).getTerminalSession().updateTerminalSessionClient(mTermuxTerminalSessionServiceClient);
 
-        mTermuxTerminalSessionActivityClient = null;
+        mActivityClients.clear();
     }
 
     /** Reset a specific session's client to the service client. Used when an activity is destroyed
@@ -781,6 +784,14 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
     public synchronized void resetSessionClient(TerminalSession session) {
         if (session != null) {
             session.updateTerminalSessionClient(mTermuxTerminalSessionServiceClient);
+        }
+    }
+
+    /** Notify all bound activities to update their session lists. Used when session attachment
+     * state changes in multi-window mode. */
+    public synchronized void notifyAllSessionListsUpdated() {
+        for (TermuxTerminalSessionActivityClient client : mActivityClients) {
+            client.termuxSessionListNotifyUpdated();
         }
     }
 

--- a/app/src/main/java/com/termux/app/terminal/TermuxSessionsListViewController.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxSessionsListViewController.java
@@ -91,8 +91,8 @@ public class TermuxSessionsListViewController extends ArrayAdapter<TermuxSession
         sessionTitleView.setTextColor(color);
 
         // Gray out sessions attached to other windows
-        TerminalSession currentSession = mActivity.getCurrentSession();
-        boolean isAttachedToOtherWindow = sessionAtRow.mAttached && sessionAtRow != currentSession;
+        boolean isAttachedToOtherWindow = mActivity.getTermuxService() != null &&
+            mActivity.getTermuxService().isSessionAttachedToOther(sessionAtRow, mActivity.getActivityId());
         if (isAttachedToOtherWindow) {
             sessionTitleView.setAlpha(0.5f);
         } else {
@@ -108,20 +108,20 @@ public class TermuxSessionsListViewController extends ArrayAdapter<TermuxSession
         if (termuxSession == null) return false;
 
         TerminalSession session = termuxSession.getTerminalSession();
-        TerminalSession currentSession = mActivity.getCurrentSession();
 
         // Disable (gray out) sessions attached to other windows
         // Sessions attached to current window should remain clickable
-        return !session.mAttached || session == currentSession;
+        if (mActivity.getTermuxService() == null) return true;
+        return !mActivity.getTermuxService().isSessionAttachedToOther(session, mActivity.getActivityId());
     }
 
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         TermuxSession clickedSession = getItem(position);
         TerminalSession session = clickedSession.getTerminalSession();
-        TerminalSession currentSession = mActivity.getCurrentSession();
         // Only switch if the session is not attached to another window
-        if (!session.mAttached || session == currentSession) {
+        if (mActivity.getTermuxService() == null ||
+            !mActivity.getTermuxService().isSessionAttachedToOther(session, mActivity.getActivityId())) {
             mActivity.getTermuxTerminalSessionClient().setCurrentSession(session);
             mActivity.getDrawer().closeDrawers();
         }

--- a/app/src/main/java/com/termux/app/terminal/TermuxSessionsListViewController.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxSessionsListViewController.java
@@ -118,8 +118,13 @@ public class TermuxSessionsListViewController extends ArrayAdapter<TermuxSession
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         TermuxSession clickedSession = getItem(position);
-        mActivity.getTermuxTerminalSessionClient().setCurrentSession(clickedSession.getTerminalSession());
-        mActivity.getDrawer().closeDrawers();
+        TerminalSession session = clickedSession.getTerminalSession();
+        TerminalSession currentSession = mActivity.getCurrentSession();
+        // Only switch if the session is not attached to another window
+        if (!session.mAttached || session == currentSession) {
+            mActivity.getTermuxTerminalSessionClient().setCurrentSession(session);
+            mActivity.getDrawer().closeDrawers();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/termux/app/terminal/TermuxSessionsListViewController.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxSessionsListViewController.java
@@ -89,7 +89,30 @@ public class TermuxSessionsListViewController extends ArrayAdapter<TermuxSession
         int defaultColor = shouldEnableDarkTheme ? Color.WHITE : Color.BLACK;
         int color = sessionRunning || sessionAtRow.getExitStatus() == 0 ? defaultColor : Color.RED;
         sessionTitleView.setTextColor(color);
+
+        // Gray out sessions attached to other windows
+        TerminalSession currentSession = mActivity.getCurrentSession();
+        boolean isAttachedToOtherWindow = sessionAtRow.mAttached && sessionAtRow != currentSession;
+        if (isAttachedToOtherWindow) {
+            sessionTitleView.setAlpha(0.5f);
+        } else {
+            sessionTitleView.setAlpha(1.0f);
+        }
+
         return sessionRowView;
+    }
+
+    @Override
+    public boolean isEnabled(int position) {
+        TermuxSession termuxSession = getItem(position);
+        if (termuxSession == null) return false;
+
+        TerminalSession session = termuxSession.getTerminalSession();
+        TerminalSession currentSession = mActivity.getCurrentSession();
+
+        // Disable (gray out) sessions attached to other windows
+        // Sessions attached to current window should remain clickable
+        return !session.mAttached || session == currentSession;
     }
 
     @Override

--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
@@ -345,7 +345,7 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
         int size = service.getTermuxSessionsSize();
         int activityId = mActivity.getActivityId();
 
-        // Find the next unattached session in the given direction
+        // Find the next session in the given direction
         int index = currentIndex;
         for (int i = 0; i < size; i++) {
             if (forward) {
@@ -357,11 +357,13 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
             TermuxSession termuxSession = service.getTermuxSession(index);
             if (termuxSession != null) {
                 TerminalSession session = termuxSession.getTerminalSession();
-                // Skip sessions attached to other windows, but allow switching to current session
-                if (!service.isSessionAttachedToOther(session, activityId)) {
+                if (service.isSessionAttachedToOther(session, activityId)) {
+                    // Session is attached to another window - focus that window
+                    service.focusActivityForSession(session);
+                } else {
                     setCurrentSession(session);
-                    return;
                 }
+                return;
             }
         }
     }
@@ -373,8 +375,10 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
         TermuxSession termuxSession = service.getTermuxSession(index);
         if (termuxSession != null) {
             TerminalSession session = termuxSession.getTerminalSession();
-            // Only switch if the session is not attached to another window
-            if (!service.isSessionAttachedToOther(session, mActivity.getActivityId())) {
+            if (service.isSessionAttachedToOther(session, mActivity.getActivityId())) {
+                // Session is attached to another window - focus that window
+                service.focusActivityForSession(session);
+            } else {
                 setCurrentSession(session);
             }
         }

--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
@@ -54,6 +54,10 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
         this.mActivity = activity;
     }
 
+    public TermuxActivity getActivity() {
+        return mActivity;
+    }
+
     /**
      * Should be called when mActivity.onCreate() is called
      */
@@ -319,7 +323,7 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
 
         // We call the following even when the session is already being displayed since config may
         // be stale, like current session not selected or scrolled to.
-        checkAndScrollToSession(session);
+        scrollToSession(session);
         updateBackgroundColor();
     }
 
@@ -494,7 +498,7 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
         mActivity.termuxSessionListNotifyUpdated();
     }
 
-    public void checkAndScrollToSession(TerminalSession session) {
+    public void scrollToSession(TerminalSession session) {
         if (!mActivity.isVisible()) return;
         TermuxService service = mActivity.getTermuxService();
         if (service == null) return;
@@ -504,7 +508,6 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
         final ListView termuxSessionsListView = mActivity.findViewById(R.id.terminal_sessions_list);
         if (termuxSessionsListView == null) return;
 
-        termuxSessionsListView.setItemChecked(indexOfSession, true);
         // Delay is necessary otherwise sometimes scroll to newly added session does not happen
         termuxSessionsListView.postDelayed(() -> termuxSessionsListView.smoothScrollToPosition(indexOfSession), 1000);
     }

--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
@@ -299,6 +299,12 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
         if (mActivity.getTerminalView().attachSession(session)) {
             // notify about switched session if not already displaying the session
             notifyOfSessionChange();
+
+            // Notify all windows that session attachment state changed so they can update their lists
+            TermuxService service = mActivity.getTermuxService();
+            if (service != null) {
+                service.notifyAllSessionListsUpdated();
+            }
         }
 
         // Set this activity's client on the session so it receives callbacks (render updates, etc.)

--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
@@ -269,6 +269,8 @@ public class TermuxTerminalViewClient extends TermuxTerminalViewClientBase {
                 showUrlSelection();
             } else if (unicodeChar == 'v') {
                 doPaste();
+            } else if (unicodeChar == 'w'/* new window */) {
+                mActivity.addNewWindow();
             } else if (unicodeChar == '+' || e.getUnicodeChar(KeyEvent.META_SHIFT_ON) == '+') {
                 // We also check for the shifted char here since shift may be required to produce '+',
                 // see https://github.com/termux/termux-api/issues/2

--- a/app/src/main/res/layout/activity_termux.xml
+++ b/app/src/main/res/layout/activity_termux.xml
@@ -69,6 +69,7 @@
                     android:longClickable="true" />
 
                 <LinearLayout
+                    android:id="@+id/drawer_buttons"
                     style="?android:attr/buttonBarStyle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -89,6 +90,15 @@
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
                         android:text="@string/action_new_session" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/new_window_button"
+                        style="?android:attr/buttonBarButtonStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:visibility="gone"
+                        android:text="@string/action_new_window" />
                 </LinearLayout>
             </LinearLayout>
 

--- a/app/src/main/res/layout/activity_termux.xml
+++ b/app/src/main/res/layout/activity_termux.xml
@@ -65,7 +65,7 @@
                     android:layout_height="0dp"
                     android:layout_gravity="top"
                     android:layout_weight="1"
-                    android:choiceMode="singleChoice"
+                    android:choiceMode="none"
                     android:longClickable="true" />
 
                 <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="action_new_session_failsafe">Failsafe</string>
     <string name="title_max_terminals_reached">Max terminals reached</string>
     <string name="msg_max_terminals_reached">Close down existing ones before creating new.</string>
+    <string name="msg_failed_to_focus_window">Failed to focus window</string>
 
     <string name="title_rename_session">Set session name</string>
     <string name="action_rename_session_confirm">Set</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
 
     <!-- Terminal Sidebar and Shortcuts -->
     <string name="action_new_session">New session</string>
+    <string name="action_new_window">New window</string>
     <string name="action_new_session_failsafe">Failsafe</string>
     <string name="title_max_terminals_reached">Max terminals reached</string>
     <string name="msg_max_terminals_reached">Close down existing ones before creating new.</string>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -24,6 +24,21 @@
     </shortcut>
 
     <shortcut
+        android:shortcutId="new_window"
+        android:enabled="true"
+        android:icon="@drawable/ic_new_session"
+        android:shortcutShortLabel="@string/action_new_window"
+        tools:targetApi="n_mr1">
+        <intent
+            android:action="android.intent.action.RUN"
+            android:targetPackage="com.termux"
+            android:targetClass="com.termux.app.TermuxActivity"
+            android:name="android.shortcut.conversation">
+            <extra android:name="com.termux.app.new_window" android:value="true"/>
+        </intent>
+    </shortcut>
+
+    <shortcut
         android:shortcutId="new_failsafe_session"
         android:enabled="true"
         android:icon="@drawable/ic_new_session"

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
@@ -68,9 +68,6 @@ public final class TerminalSession extends TerminalOutput {
     /** Set by the application for user identification of session, not by terminal. */
     public String mSessionName;
 
-    /** Whether this session is attached to a TerminalView. Used for multi-window support. */
-    public boolean mAttached;
-
     final Handler mMainThreadHandler = new MainThreadHandler();
 
     private final String mShellPath;

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
@@ -68,6 +68,9 @@ public final class TerminalSession extends TerminalOutput {
     /** Set by the application for user identification of session, not by terminal. */
     public String mSessionName;
 
+    /** Whether this session is attached to a TerminalView. Used for multi-window support. */
+    public boolean mAttached;
+
     final Handler mMainThreadHandler = new MainThreadHandler();
 
     private final String mShellPath;

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -291,9 +291,19 @@ public final class TerminalView extends View {
         if (session == mTermSession) return false;
         mTopRow = 0;
 
+        // Detach the old session
+        if (mTermSession != null) {
+            mTermSession.mAttached = false;
+        }
+
         mTermSession = session;
         mEmulator = null;
         mCombiningAccent = 0;
+
+        // Attach the new session
+        if (mTermSession != null) {
+            mTermSession.mAttached = true;
+        }
 
         updateSize();
 
@@ -301,6 +311,15 @@ public final class TerminalView extends View {
         setVerticalScrollBarEnabled(true);
 
         return true;
+    }
+
+    /**
+     * Detach the current session from this view.
+     */
+    public void detachSession() {
+        if (mTermSession != null) {
+            mTermSession.mAttached = false;
+        }
     }
 
     @Override

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -284,42 +284,38 @@ public final class TerminalView extends View {
 
     /**
      * Attach a {@link TerminalSession} to this view.
+     * Note: The caller (activity) is responsible for managing attachment state via the service.
      *
      * @param session The {@link TerminalSession} this view will be displaying.
+     * @return The previous session that was attached (may be null), so caller can detach it
      */
-    public boolean attachSession(TerminalSession session) {
-        if (session == mTermSession) return false;
+    public TerminalSession attachSession(TerminalSession session) {
+        if (session == mTermSession) return null;
         mTopRow = 0;
 
-        // Detach the old session
-        if (mTermSession != null) {
-            mTermSession.mAttached = false;
-        }
+        TerminalSession previousSession = mTermSession;
 
         mTermSession = session;
         mEmulator = null;
         mCombiningAccent = 0;
-
-        // Attach the new session
-        if (mTermSession != null) {
-            mTermSession.mAttached = true;
-        }
 
         updateSize();
 
         // Wait with enabling the scrollbar until we have a terminal to get scroll position from.
         setVerticalScrollBarEnabled(true);
 
-        return true;
+        return previousSession;
     }
 
     /**
      * Detach the current session from this view.
+     * Note: The caller (activity) is responsible for managing attachment state via the service.
+     * @return The session that was detached (may be null)
      */
-    public void detachSession() {
-        if (mTermSession != null) {
-            mTermSession.mAttached = false;
-        }
+    public TerminalSession detachSession() {
+        TerminalSession previousSession = mTermSession;
+        mTermSession = null;
+        return previousSession;
     }
 
     @Override

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
@@ -945,6 +945,9 @@ public final class TermuxConstants {
             /** Intent extra for if termux failsafe session needs to be started and is used by {@link TERMUX_ACTIVITY} and {@link TERMUX_SERVICE#ACTION_STOP_SERVICE} */
             public static final String EXTRA_FAILSAFE_SESSION = TermuxConstants.TERMUX_PACKAGE_NAME + ".app.failsafe_session"; // Default: "com.termux.app.failsafe_session"
 
+            /** Intent extra for if a new window should be opened instead of a new session */
+            public static final String EXTRA_NEW_WINDOW = TermuxConstants.TERMUX_PACKAGE_NAME + ".app.new_window"; // Default: "com.termux.app.new_window"
+
 
             /** Intent action to make termux app notify user that a crash happened. */
             public static final String ACTION_NOTIFY_APP_CRASH = TermuxConstants.TERMUX_PACKAGE_NAME + ".app.notify_app_crash"; // Default: "com.termux.app.notify_app_crash"


### PR DESCRIPTION
Adds support for multi-window mode on android 7+. Replaces #187.

Replicates the changes from the previous pr with the following differences:
- extends the existing `TerminalSessionClient` interface with support for multiple activities
- session claiming is atomic to prevent race conditions
- additional safety checks added to prevent session stealing
- new window shortcut is always allowed in normal mode, and the os splits the current window with the new one automatically

## Testing

Tested on:
- (left) Samsung Galaxy Tab S7 FE 5G, running Android 14, in samsung (new) dex mode
- (right) Oneplus 12, running Android 15.

<div>
<img width="75%" src="https://github.com/user-attachments/assets/f9f86347-2e87-441d-a54f-0f125e95b186"/>
<img width="24%" src="https://github.com/user-attachments/assets/1669791a-fbb2-45c5-8fcf-41ec9185bf40"/>
</div>
