### PR TITLE
Increase read buffer size from 4KB to 64KB

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
@@ -41,7 +41,7 @@ public final class TerminalSession extends TerminalOutput {
      * A queue written to from a separate thread when the process outputs, and read by main thread to process by
      * terminal emulator.
      */
-    final ByteQueue mProcessToTerminalIOQueue = new ByteQueue(4096);
+    final ByteQueue mProcessToTerminalIOQueue = new ByteQueue(64 * 1024);
     /**
      * A queue written to from the main thread due to user interaction, and read by another thread which forwards by
      * writing to the {@link #mTerminalFileDescriptor}.
@@ -336,7 +336,7 @@ public final class TerminalSession extends TerminalOutput {
     @SuppressLint("HandlerLeak")
     class MainThreadHandler extends Handler {
 
-        final byte[] mReceiveBuffer = new byte[4 * 1024];
+        final byte[] mReceiveBuffer = new byte[64 * 1024];
 
         @Override
         public void handleMessage(Message msg) {


### PR DESCRIPTION
Fixes #4976.

I've tested very large content streaming scenarios (`chafa`-ing dozens of large images). `master` lags to a painfully unusable state where the terminal emulator remains unresponsive for up to minutes.

With this patch it's very smooth and scrolling in the multiplexer also works perfectly. 64KB seems a much more sensible size than 4KB it appears.