### PR TITLE
Fixed: Improve dark mode support for settings and shared activities

### DIFF
--- a/termux-shared/src/main/java/com/termux/shared/activities/TextIOActivity.java
+++ b/termux-shared/src/main/java/com/termux/shared/activities/TextIOActivity.java
@@ -24,9 +24,11 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
+import com.termux.shared.activity.media.AppCompatActivityUtils;
 import com.termux.shared.interact.ShareUtils;
 import com.termux.shared.logger.Logger;
 import com.termux.shared.R;
+import com.termux.shared.theme.NightMode;
 import com.termux.shared.models.TextIOInfo;
 import com.termux.shared.view.KeyboardUtils;
 
@@ -62,6 +64,8 @@ public class TextIOActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Logger.logVerbose(LOG_TAG, "onCreate");
+
+        AppCompatActivityUtils.setNightMode(this, NightMode.getAppNightMode().getName(), true);
 
         setContentView(R.layout.activity_text_io);
 

--- a/termux-shared/src/main/java/com/termux/shared/interact/MessageDialogUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/interact/MessageDialogUtils.java
@@ -4,7 +4,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.graphics.Color;
+import android.content.res.TypedArray;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
@@ -51,7 +51,7 @@ public class MessageDialogUtils {
                                    final DialogInterface.OnClickListener onNegativeButton,
                                    final DialogInterface.OnDismissListener onDismiss) {
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(context, androidx.appcompat.R.style.Theme_AppCompat_Light_Dialog);
+        AlertDialog.Builder builder = new AlertDialog.Builder(context, androidx.appcompat.R.style.Theme_AppCompat_DayNight_Dialog);
 
         LayoutInflater inflater = (LayoutInflater) context.getSystemService( Context.LAYOUT_INFLATER_SERVICE );
         View view = inflater.inflate(R.layout.dialog_show_message, null);
@@ -81,12 +81,17 @@ public class MessageDialogUtils {
 
         dialog.setOnShowListener(dialogInterface -> {
             Logger.logError("dialog");
+            int[] attrs = new int[] { android.R.attr.textColorPrimary };
+            TypedArray ta = context.obtainStyledAttributes(attrs);
+            int textColor = ta.getColor(0, 0xFF000000);
+            ta.recycle();
+
             Button button = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
             if (button != null)
-                button.setTextColor(Color.BLACK);
+                button.setTextColor(textColor);
             button = dialog.getButton(AlertDialog.BUTTON_NEGATIVE);
             if (button != null)
-                button.setTextColor(Color.BLACK);
+                button.setTextColor(textColor);
         });
 
         dialog.show();

--- a/termux-shared/src/main/res/layout/dialog_show_message.xml
+++ b/termux-shared/src/main/res/layout/dialog_show_message.xml
@@ -17,7 +17,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="@style/TextAppearance.AppCompat.Title"
-            android:textColor="@android:color/white"/>
+            android:textColor="?android:attr/textColorPrimaryInverse"/>
     </LinearLayout>
 
     <ScrollView
@@ -37,8 +37,8 @@
                 android:layout_height="wrap_content"
                 android:autoLink="web|email"
                 android:textSize="14sp"
-                android:textColor="@android:color/tab_indicator_text"
-                android:textColorLink="@android:color/black"/>
+                android:textColor="?android:attr/textColorPrimary"
+                android:textColorLink="?android:attr/textColorLink"/>
         </LinearLayout>
     </ScrollView>
 

--- a/termux-shared/src/main/res/layout/partial_primary_toolbar.xml
+++ b/termux-shared/src/main/res/layout/partial_primary_toolbar.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.appbar.AppBarLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar_container"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:layout_height="wrap_content">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
@@ -19,4 +19,4 @@
         app:subtitleTextAppearance="@style/TextAppearance.Widget.BaseToolbar.Subtitle">
     </androidx.appcompat.widget.Toolbar>
 
-</LinearLayout>
+</com.google.android.material.appbar.AppBarLayout>

--- a/termux-shared/src/main/res/values-night/colors.xml
+++ b/termux-shared/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="background_markdown_code_inline">#1FFFFFFF</color>
+    <color name="background_markdown_code_block">#0FFFFFFF</color>
+</resources>

--- a/termux-shared/src/main/res/values-night/themes.xml
+++ b/termux-shared/src/main/res/values-night/themes.xml
@@ -9,17 +9,20 @@
     -->
     <style name="Theme.BaseActivity.DayNight.DarkActionBar" parent="Theme.MaterialComponents">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/red_400</item>
-        <item name="colorPrimaryVariant">@color/red_800</item>
-        <item name="colorOnPrimary">@color/black</item>
+        <item name="colorPrimary">@color/grey_900</item>
+        <item name="colorPrimaryVariant">@color/black</item>
+        <item name="colorOnPrimary">@color/white</item>
 
         <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/grey_400</item>
         <item name="colorSecondaryVariant">@color/grey_500</item>
         <item name="colorOnSecondary">@color/black</item>
 
+        <!-- Accent color for widgets (switches, checkboxes, etc.). -->
+        <item name="colorAccent">@color/red_400</item>
+
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@color/grey_900</item>
         <item name="colorPrimaryDark" tools:targetApi="l">?attr/colorPrimary</item>
 
         <!-- Text color. -->

--- a/termux-shared/src/main/res/values/themes.xml
+++ b/termux-shared/src/main/res/values/themes.xml
@@ -20,9 +20,12 @@
         <item name="colorSecondaryVariant">@color/black</item>
         <item name="colorOnSecondary">@color/white</item>
 
+        <!-- Toolbar / ActionBar background color. -->
+        <item name="colorPrimaryDark" tools:targetApi="l">@color/white</item>
+
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
-        <item name="colorPrimaryDark" tools:targetApi="l">?attr/colorPrimary</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@color/white</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
 
         <!-- Text color. -->
         <item name="android:textColorPrimary">@color/black</item>


### PR DESCRIPTION
## Summary

- Settings screen (SettingsActivity), ReportActivity, TextIOActivity, and message dialogs now properly follow system dark mode
- Replaced hardcoded light-only colors in `dialog_show_message.xml` and `MessageDialogUtils.java` with theme attributes
- Added `setNightMode()` call to `TextIOActivity` (was missing, unlike `ReportActivity` which already had it)
- Updated toolbar to use neutral surface colors instead of the red brand color in both light and dark modes
- Wrapped toolbar in `AppBarLayout` for proper elevation shadow
- Added `values-night/colors.xml` for dark-appropriate markdown code block background colors

## Screenshots

|  | Light mode | Dark mode |
|---|---|---|
| **Before** | <img width="360" alt="screenshot_before_light" src="https://github.com/user-attachments/assets/5a8d96ce-5df5-4f16-b92d-d49fa5326df2" /> | <img width="360" alt="screenshot_before_dark" src="https://github.com/user-attachments/assets/09a52b04-6044-430e-a31b-608fbca211d9" /> |
| **After** | <img width="360" alt="screenshot_light" src="https://github.com/user-attachments/assets/1ee6bb70-abf1-4115-b658-f236511b7180" /> | <img width="360" alt="screenshot_dark" src="https://github.com/user-attachments/assets/6e0d9111-b146-4aed-b8bc-916f98729ef2" /> |

## Test plan

- [ ] System dark mode ON → Settings screen displays with dark background and neutral toolbar
- [ ] System light mode ON → Settings screen displays with white background/toolbar with elevation shadow
- [ ] Terminal screen appearance unchanged
- [ ] Sidebar (session list) appearance unchanged
- [ ] Terminal long-press context menu appearance unchanged
- [ ] `use-black-ui=true` setting still works
- [ ] All PreferenceFragments (Termux, API, Float, Tasker, Widget) follow dark mode
- [ ] ReportActivity and TextIOActivity follow dark mode
- [ ] Message dialogs follow dark mode

Fixes https://github.com/termux/termux-app/issues/2900

🤖 Generated with [Claude Code](https://claude.com/claude-code)