### PR TITLE
Fix(terminal-emulator): Trim synthetic wide-char trailing blank on copy (#1397)

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -93,7 +93,8 @@ public final class TerminalBuffer {
 
                if (lastPrintingCharIndex >= x1Index && line[lastPrintingCharIndex] == ' ') {
         int prevPrintingCharIndex = lastPrintingCharIndex - 1;
-        if (prevPrintingCharIndex >= x1Index && WcWidth.width(Character.codePointAt(line, prevPrintingCharIndex)) == 2) {
+                int prevCodePointIndex = Character.isLowSurrogate(line[prevPrintingCharIndex]) ? prevPrintingCharIndex - 1 : prevPrintingCharIndex;
+        if (prevCodePointIndex >= x1Index && WcWidth.width(Character.codePointAt(line, prevCodePointIndex)) == 2) {
             // Only trim if the double-width char starts at the last column.
             // This is when the terminal inserts a synthetic trailing blank.
             int colOfPrev = lineObject.findStartOfColumn(columns - 1);

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -87,6 +87,16 @@ public final class TerminalBuffer {
             if (rowLineWrap && x2 == columns) {
                 // If the line was wrapped, we shouldn't lose trailing space:
                 lastPrintingCharIndex = x2Index - 1;
+                        // Keep trailing spaces for wrapped lines, except for the synthetic
+        // blank that can appear when a double-width character wraps at the
+        // last available column.
+
+        if (lastPrintingCharIndex >= x1Index && line[lastPrintingCharIndex] == ' ') {
+            int prevPrintingCharIndex = lastPrintingCharIndex - 1;
+            if (prevPrintingCharIndex >= x1Index && WcWidth.width(line[prevPrintingCharIndex]) == 2) {
+                lastPrintingCharIndex--;
+            }
+        }
             } else {
                 for (i = x1Index; i < x2Index; ++i) {
                     char c = line[i];

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -93,7 +93,7 @@ public final class TerminalBuffer {
 
                if (lastPrintingCharIndex >= x1Index && line[lastPrintingCharIndex] == ' ') {
         int prevPrintingCharIndex = lastPrintingCharIndex - 1;
-        if (prevPrintingCharIndex >= x1Index && WcWidth.width(line[prevPrintingCharIndex]) == 2) {
+        if (prevPrintingCharIndex >= x1Index && WcWidth.width(Character.codePointAt(line, prevPrintingCharIndex)) == 2) {
             // Only trim if the double-width char starts at the last column.
             // This is when the terminal inserts a synthetic trailing blank.
             int colOfPrev = lineObject.findStartOfColumn(columns - 1);

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -91,12 +91,17 @@ public final class TerminalBuffer {
         // blank that can appear when a double-width character wraps at the
         // last available column.
 
-        if (lastPrintingCharIndex >= x1Index && line[lastPrintingCharIndex] == ' ') {
-            int prevPrintingCharIndex = lastPrintingCharIndex - 1;
-            if (prevPrintingCharIndex >= x1Index && WcWidth.width(line[prevPrintingCharIndex]) == 2) {
+               if (lastPrintingCharIndex >= x1Index && line[lastPrintingCharIndex] == ' ') {
+        int prevPrintingCharIndex = lastPrintingCharIndex - 1;
+        if (prevPrintingCharIndex >= x1Index && WcWidth.width(line[prevPrintingCharIndex]) == 2) {
+            // Only trim if the double-width char starts at the last column.
+            // This is when the terminal inserts a synthetic trailing blank.
+            int colOfPrev = lineObject.findStartOfColumn(columns - 1);
+            if (colOfPrev == prevPrintingCharIndex) {
                 lastPrintingCharIndex--;
             }
         }
+    }
             } else {
                 for (i = x1Index; i < x2Index; ++i) {
                     char c = line[i];


### PR DESCRIPTION
…copy (#1397)

Fixes #1397

When a double-width (CJK) character wraps at the end of a line, the terminal inserts a placeholder space in the last column. This commit adds logic to trim that synthetic trailing blank during copy operations when the preceding copied character is double-width, while preserving legitimate trailing spaces on wrapped lines.

Changes only TerminalBuffer.getSelectedText() - no changes to rendering, storage, or wrapping logic.