### PR TITLE
Downgrade GitHub Actions to v4 and add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/attach_debug_apks_to_release.yml
+++ b/.github/workflows/attach_debug_apks_to_release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.GITHUB_REF }}
 

--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build:
@@ -19,10 +20,10 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup java 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -85,7 +86,7 @@ jobs:
           fi
 
       - name: Attach universal APK file
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APK_BASENAME_PREFIX }}_universal
           path: |
@@ -93,7 +94,7 @@ jobs:
             ${{ env.APK_DIR_PATH }}/output-metadata.json
 
       - name: Attach arm64-v8a APK file
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APK_BASENAME_PREFIX }}_arm64-v8a
           path: |
@@ -101,7 +102,7 @@ jobs:
             ${{ env.APK_DIR_PATH }}/output-metadata.json
 
       - name: Attach armeabi-v7a APK file
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APK_BASENAME_PREFIX }}_armeabi-v7a
           path: |
@@ -109,7 +110,7 @@ jobs:
             ${{ env.APK_DIR_PATH }}/output-metadata.json
 
       - name: Attach x86_64 APK file
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APK_BASENAME_PREFIX }}_x86_64
           path: |
@@ -117,7 +118,7 @@ jobs:
             ${{ env.APK_DIR_PATH }}/output-metadata.json
 
       - name: Attach x86 APK file
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APK_BASENAME_PREFIX }}_x86
           path: |
@@ -125,7 +126,7 @@ jobs:
             ${{ env.APK_DIR_PATH }}/output-metadata.json
 
       - name: Attach sha256sums file
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APK_BASENAME_PREFIX }}_sha256sums
           path: |

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
     - name: Setup Java
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 17
     - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@v5
+      uses: gradle/actions/dependency-submission@v3

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -15,5 +15,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: gradle/actions/wrapper-validation@5
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
     - name: Setup java 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions workflows to use older versions of actions and adds manual workflow dispatch capability to the debug build workflow.

## Key Changes
- **Action version downgrades**: Downgraded all GitHub Actions to v4 versions:
  - `actions/checkout`: v6 → v4
  - `actions/setup-java`: v5 → v4
  - `actions/upload-artifact`: v6 → v4
  - `gradle/actions/dependency-submission`: v5 → v3
  - `gradle/actions/wrapper-validation`: v5 → v3

- **Workflow dispatch trigger**: Added `workflow_dispatch` to the debug_build.yml workflow, allowing manual triggering of the build workflow from the GitHub Actions UI

## Affected Workflows
- `.github/workflows/debug_build.yml`
- `.github/workflows/dependency-submission.yml`
- `.github/workflows/gradle-wrapper-validation.yml`
- `.github/workflows/run_tests.yml`
- `.github/workflows/attach_debug_apks_to_release.yml`

## Notes
These version downgrades may be necessary for compatibility with specific GitHub Actions runner environments or to address known issues with newer versions.

https://claude.ai/code/session_01XPjt7Dxds6TJCwSU2ehgL8