### PR TITLE
Close FileInputStream in code

### DIFF
--- a/app/src/main/java/com/termux/app/api/file/FileReceiverActivity.java
+++ b/app/src/main/java/com/termux/app/api/file/FileReceiverActivity.java
@@ -114,10 +114,11 @@ public class FileReceiverActivity extends AppCompatActivity {
 
                 File file = new File(path);
                 try {
-                    FileInputStream in = new FileInputStream(file);
-                    promptNameAndSave(in, file.getName());
-                } catch (FileNotFoundException e) {
-                    showErrorDialogAndQuit("Cannot open file: " + e.getMessage() + ".");
+                    try (FileInputStream in = new FileInputStream(file)) {
+                        promptNameAndSave(in, file.getName());
+                        } catch (FileNotFoundException e) {
+                        showErrorDialogAndQuit("Cannot open file: " + e.getMessage() + ".");
+                    }
                 }
             } else {
                 showErrorDialogAndQuit("Unable to receive any file or URL.");


### PR DESCRIPTION
The current code in app/src/main/java/com/termux/app/api/file/FileReceiverActivity.java likely works fine most of the time, but The resource opened there can leak if code exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Close this if it’s not worth it.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.