### PR TITLE
Fixed(terminal): Preserve scrollback position during streaming output

### DIFF
--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -460,24 +460,25 @@ public final class TerminalView extends View {
         int rowsInHistory = mEmulator.getScreen().getActiveTranscriptRows();
         if (mTopRow < -rowsInHistory) mTopRow = -rowsInHistory;
 
-        if (isSelectingText() || mEmulator.isAutoScrollDisabled()) {
+        boolean keepScrollPosition = isSelectingText() || mEmulator.isAutoScrollDisabled() || mTopRow != 0;
+        if (keepScrollPosition) {
 
-            // Do not scroll when selecting text.
+            // Keep viewport pinned when selecting text, when auto-scroll is disabled,
+            // or when user has manually scrolled up from bottom.
             int rowShift = mEmulator.getScrollCounter();
             if (-mTopRow + rowShift > rowsInHistory) {
-                // .. unless we're hitting the end of history transcript, in which
-                // case we abort text selection and scroll to end.
+                // We cannot keep the exact viewport if old transcript rows have already
+                // been dropped, so clamp to the oldest available row in history.
                 if (isSelectingText())
                     stopTextSelectionMode();
 
-                if (mEmulator.isAutoScrollDisabled()) {
-                    mTopRow = -rowsInHistory;
-                    skipScrolling = true;
-                }
+                mTopRow = -rowsInHistory;
+                skipScrolling = true;
             } else {
                 skipScrolling = true;
                 mTopRow -= rowShift;
-                decrementYTextSelectionCursors(rowShift);
+                if (isSelectingText())
+                    decrementYTextSelectionCursors(rowShift);
             }
         }
 


### PR DESCRIPTION
### Problem
When terminal output is continuously streaming, manually scrolling up does not stick: the viewport is forced back to the bottom on subsequent screen updates. This makes it difficult to inspect earlier output from long-running commands.

### Root cause
`TerminalView.onScreenUpdated()` currently auto-scrolls to bottom whenever `mTopRow != 0`, except in text selection mode or when emulator auto-scroll is disabled.

### Changes
- **File:** `terminal-view/src/main/java/com/termux/view/TerminalView.java`
- **Method:** `onScreenUpdated(boolean skipScrolling)`

Behavior updates:
1. Treat `mTopRow != 0` (user manually scrolled up) as a keep-position condition.
2. While keeping position, adjust viewport by `rowShift` (`mTopRow -= rowShift`) so visible content remains stable as new lines arrive.
3. If transcript overflow drops old lines, clamp to oldest available history row (`mTopRow = -rowsInHistory`).
4. Only adjust text-selection cursor positions when selection mode is active.

### Result
- User can scroll up and read scrollback while output keeps streaming.
- No forced snap-to-bottom on each update when user is off-bottom.
- Normal follow behavior remains when user is at bottom.

### Related issue
Related to #1242

### Validation
- Change is localized to `TerminalView` scroll/follow policy.
- No API changes, no terminal-core/session behavior changes.
- Local full Gradle validation was limited by environment NDK setup issue (`source.properties` missing); CI should validate on clean runners.
