### PR TITLE
Fix: terminal freezes when activity is destroyed while new instance already bound

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -354,7 +354,9 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
 
         if (mTermuxService != null) {
             // Do not leave service and session clients with references to activity.
-            mTermuxService.unsetTermuxTerminalSessionClient();
+            // Pass our own client so we don't clobber a newer activity's client if we are being
+            // destroyed while a new instance has already bound (e.g. after home-launcher restart).
+            mTermuxService.unsetTermuxTerminalSessionClient(mTermuxTerminalSessionActivityClient);
             mTermuxService = null;
         }
 

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -775,6 +775,13 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
         mTermuxTerminalSessionActivityClient = null;
     }
 
+    /** Only unsets the client if it matches {@code client}, so a newly bound activity's client is
+     *  not clobbered by a previous activity's {@code onDestroy()}. */
+    public synchronized void unsetTermuxTerminalSessionClient(TermuxTerminalSessionActivityClient client) {
+        if (mTermuxTerminalSessionActivityClient == client)
+            unsetTermuxTerminalSessionClient();
+    }
+
 
 
 


### PR DESCRIPTION
## Summary

When the activity is recreated — either after `recreate()` (e.g. theme/style reload) or when Termux is used as a home launcher and a new instance starts after Exit — the new `TermuxActivity` can bind to the service and call `setTermuxTerminalSessionClient()` **before** the old activity's `onDestroy()` runs.

The old `onDestroy()` then calls `unsetTermuxTerminalSessionClient()` unconditionally, replacing the new activity's session client with the no-op `TermuxTerminalSessionServiceClient`. This causes `onTextChanged()` to stop triggering terminal redraws — the terminal appears completely frozen until the app is force-stopped.

## Root cause

`TermuxActivity.onDestroy()`:
```java
mTermuxService.unsetTermuxTerminalSessionClient(); // unconditional
```

Android's lifecycle guarantees the new instance reaches `onResume()` before the old one's `onDestroy()` fires. `onServiceConnected()` (which calls `setTermuxTerminalSessionClient()`) is delivered on the main thread shortly after `bindService()` in `onCreate()`, so it reliably arrives before `onDestroy()` of the outgoing activity.

## Fix

Add a guarded overload `unsetTermuxTerminalSessionClient(client)` that only unsets if the stored client still matches the caller. Use it from `onDestroy()` instead of the unconditional version.

## Reproduction

Reliable: configure Termux as a home launcher, tap "Exit" in the notification. The restarted terminal will be completely frozen (no output rendered). Toggling the soft keyboard or extra-keys bar forces a single redraw but the freeze persists until force-stop.

The same race occurs on any theme-reload that calls `recreate()`.