### PR TITLE
feat: add opt-in home screen launcher via termux.properties

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,20 @@
         </activity>
 
         <activity-alias
+            android:name=".app.HomeLauncherActivity"
+            android:enabled="false"
+            android:exported="true"
+            android:targetActivity=".app.TermuxActivity">
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity-alias>
+
+        <activity-alias
             android:name=".HomeActivity"
             android:exported="true"
             android:targetActivity=".app.TermuxActivity">

--- a/app/src/main/java/com/termux/app/api/file/FileReceiverActivity.java
+++ b/app/src/main/java/com/termux/app/api/file/FileReceiverActivity.java
@@ -280,6 +280,14 @@ public class FileReceiverActivity extends AppCompatActivity {
                 if (errmsg != null)
                     Logger.logError(LOG_TAG, errmsg);
 
+                state = properties.isHomeLauncherEnabled();
+                Logger.logVerbose(LOG_TAG, "Setting " + TERMUX_APP.HOME_LAUNCHER_ACTIVITY_CLASS_NAME + " component state to " + state);
+                errmsg = PackageUtils.setComponentState(context, TermuxConstants.TERMUX_PACKAGE_NAME,
+                    TERMUX_APP.HOME_LAUNCHER_ACTIVITY_CLASS_NAME,
+                    state, null, false, false);
+                if (errmsg != null)
+                    Logger.logError(LOG_TAG, errmsg);
+
             }
         }.start();
     }

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
@@ -933,6 +933,9 @@ public final class TermuxConstants {
         /** Termux app FileViewReceiverActivity class name */
         public static final String FILE_VIEW_RECEIVER_ACTIVITY_CLASS_NAME = TERMUX_PACKAGE_NAME + ".app.api.file.FileViewReceiverActivity"; // Default: "com.termux.app.api.file.FileViewReceiverActivity"
 
+        /** Termux app HomeLauncherActivity alias class name */
+        public static final String HOME_LAUNCHER_ACTIVITY_CLASS_NAME = TERMUX_PACKAGE_NAME + ".app.HomeLauncherActivity"; // Default: "com.termux.app.HomeLauncherActivity"
+
 
         /** Termux app core activity name. */
         public static final String TERMUX_ACTIVITY_NAME = TERMUX_PACKAGE_NAME + ".app.TermuxActivity"; // Default: "com.termux.app.TermuxActivity"

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxPropertyConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxPropertyConstants.java
@@ -105,6 +105,9 @@ public final class TermuxPropertyConstants {
     /** Defines the key for whether file view receiver of the app is enabled. */
     public static final String KEY_DISABLE_FILE_VIEW_RECEIVER =  "disable-file-view-receiver"; // Default: "disable-file-view-receiver"
 
+    /** Defines the key for whether home screen launcher is enabled. */
+    public static final String KEY_ENABLE_HOME_SCREEN_LAUNCHER = "enable-home-screen-launcher"; // Default: false
+
 
 
     /** Defines the key for whether hardware keyboard shortcuts are enabled. */
@@ -393,6 +396,7 @@ public final class TermuxPropertyConstants {
         /* boolean */
         KEY_DISABLE_FILE_SHARE_RECEIVER,
         KEY_DISABLE_FILE_VIEW_RECEIVER,
+        KEY_ENABLE_HOME_SCREEN_LAUNCHER,
         KEY_DISABLE_HARDWARE_KEYBOARD_SHORTCUTS,
         KEY_DISABLE_TERMINAL_SESSION_CHANGE_TOAST,
         KEY_ENFORCE_CHAR_BASED_INPUT,
@@ -441,6 +445,7 @@ public final class TermuxPropertyConstants {
     public static final Set<String> TERMUX_DEFAULT_FALSE_BOOLEAN_BEHAVIOUR_PROPERTIES_LIST = new HashSet<>(Arrays.asList(
         KEY_DISABLE_FILE_SHARE_RECEIVER,
         KEY_DISABLE_FILE_VIEW_RECEIVER,
+        KEY_ENABLE_HOME_SCREEN_LAUNCHER,
         KEY_DISABLE_HARDWARE_KEYBOARD_SHORTCUTS,
         KEY_DISABLE_TERMINAL_SESSION_CHANGE_TOAST,
         KEY_ENFORCE_CHAR_BASED_INPUT,

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
@@ -586,6 +586,10 @@ public abstract class TermuxSharedProperties {
         return (boolean) getInternalPropertyValue(TermuxPropertyConstants.KEY_DISABLE_FILE_VIEW_RECEIVER, true);
     }
 
+    public boolean isHomeLauncherEnabled() {
+        return (boolean) getInternalPropertyValue(TermuxPropertyConstants.KEY_ENABLE_HOME_SCREEN_LAUNCHER, true);
+    }
+
     public boolean areHardwareKeyboardShortcutsDisabled() {
         return (boolean) getInternalPropertyValue(TermuxPropertyConstants.KEY_DISABLE_HARDWARE_KEYBOARD_SHORTCUTS, true);
     }


### PR DESCRIPTION
## Summary

Adds Termux as an optional home screen launcher, disabled by default. This implements the feature requested in #206.

- Adds a `HomeLauncherActivity` activity-alias (disabled by default) with `HOME` and `DEFAULT` intent filters
- Adds `enable-home-screen-launcher` property to `termux.properties` — set to `true` to enable
- The component state is toggled at runtime in `updateFileReceiverActivityComponentsState()`, consistent with how `disable-file-share-receiver` and `disable-file-view-receiver` are handled

## How to enable

Add to `~/.termux/termux.properties`:
```
enable-home-screen-launcher=true
```

Then restart Termux. You can then select Termux as your home app from system Settings → Apps → Default apps → Home app.

Closes #206