### PR TITLE
Fixed: Fix typos, grammar, and resource management issues

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: gradle/actions/wrapper-validation@5
+      - uses: gradle/wrapper-validation-action@v3

--- a/app/src/main/java/com/termux/app/TermuxInstaller.java
+++ b/app/src/main/java/com/termux/app/TermuxInstaller.java
@@ -50,7 +50,7 @@ import static com.termux.shared.termux.TermuxConstants.TERMUX_STAGING_PREFIX_DIR
  * <p/>
  * (4) The zip file is loaded from a shared library.
  * <p/>
- * (5) The zip, containing entries relative to the $PREFIX, is is downloaded and extracted by a zip input stream
+ * (5) The zip, containing entries relative to the $PREFIX, is downloaded and extracted by a zip input stream
  * continuously encountering zip file entries:
  * <p/>
  * (5.1) If the zip entry encountered is SYMLINKS.txt, go through it and remember all symlinks to setup.

--- a/app/src/main/java/com/termux/app/TermuxInstaller.java
+++ b/app/src/main/java/com/termux/app/TermuxInstaller.java
@@ -102,7 +102,7 @@ final class TermuxInstaller {
             return;
         }
 
-        // If prefix directory exists, even if its a symlink to a valid directory and symlink is not broken/dangling
+        // If prefix directory exists, even if it's a symlink to a valid directory and symlink is not broken/dangling
         if (FileUtils.directoryFileExists(TERMUX_PREFIX_DIR_PATH, true)) {
             if (TermuxFileUtils.isTermuxPrefixDirectoryEmpty()) {
                 Logger.logInfo(LOG_TAG, "The termux prefix directory \"" + TERMUX_PREFIX_DIR_PATH + "\" exists but is empty or only contains specific unimportant files.");

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -251,7 +251,7 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
      * creators for plugin commands but we still try to process whatever results can be processed
      * despite the unreliable behaviour of onDestroy().
      *
-     * Note that if don't kill the processes started by plugins which **expect** the result back
+     * Note that if we don't kill the processes started by plugins which **expect** the result back
      * and notify their creators that they have been killed, then they may get stuck waiting for
      * the results forever like in case of commands started by Termux:Tasker or RUN_COMMAND intent,
      * since once TermuxService has been killed, no result will be sent back. They may still get

--- a/app/src/main/java/com/termux/app/terminal/TermuxActivityRootView.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxActivityRootView.java
@@ -30,7 +30,7 @@ import com.termux.shared.view.ViewUtils;
  * instead of the default `InputType.TYPE_NULL` for termux, some keyboards may still show suggestions.
  * Gboard does too, but only when text is copied and clipboard suggestions **and** number keys row
  * toggles are enabled in its settings. When number keys row toggle is not enabled, Gboard will still
- * show the row but will switch it with suggestions if needed. If its enabled, then number keys row
+ * show the row but will switch it with suggestions if needed. If it's enabled, then number keys row
  * is always shown and suggestions are shown in an additional row on top of it. This additional row is likely
  * part of the candidates view returned by the keyboard app in {@link InputMethodService#onCreateCandidatesView()}.
  *
@@ -40,7 +40,7 @@ import com.termux.shared.view.ViewUtils;
  * up the view or because Gboard does not include the candidate's view height in the height reported
  * to android that should be used, hence causing an overlap.
  *
- * Gboard logs the following entry to `logcat` when its opened with or without the suggestions bar showing:
+ * Gboard logs the following entry to `logcat` when it's opened with or without the suggestions bar showing:
  * I/KeyboardViewUtil: KeyboardViewUtil.calculateMaxKeyboardBodyHeight():62 leave 500 height for app when screen height:2392, header height:176 and isFullscreenMode:false, so the max keyboard body height is:1716
  * where `keyboard_height = screen_height - height_for_app - header_height` (62 is a hardcoded value in Gboard source code and may be a version number)
  * So this may in fact be due to Gboard but https://stackoverflow.com/questions/57567272 suggests
@@ -55,7 +55,7 @@ import com.termux.shared.view.ViewUtils;
  * activity theme. When {@link TermuxActivity} {@link ViewTreeObserver.OnGlobalLayoutListener} is
  * called when any of the sub view layouts change,  like keyboard opening/closing keyboard,
  * extra keys/input view switched, etc, we check if the bottom space view is visible or not.
- * If its not, then we add a margin to the bottom of the root view, so that the keyboard does not
+ * If it's not, then we add a margin to the bottom of the root view, so that the keyboard does not
  * overlap the extra keys/terminal, since the margin will push up the view. By default the margin
  * added is equal to the height of the hidden part of extra keys/terminal. For Gboard's case, the
  * hidden part equals the `header_height`. The updates to margins may cause a jitter in some cases
@@ -173,7 +173,7 @@ public class TermuxActivityRootView extends LinearLayout implements ViewTreeObse
                 // cases when view has been redrawn with new margin because bottom space view was
                 // hidden by keyboard and then view was redrawn again due to layout change (like
                 // keyboard symbol view is switched to), android will add margin below its new position
-                // if its greater than 0, which was already above the keyboard creating x2x margin.
+                // if it's greater than 0, which was already above the keyboard creating x2x margin.
                 // Adding time check since moving split screen divider in landscape causes jitter
                 // and prevents some infinite loops
                 if ((System.currentTimeMillis() - lastMarginBottomTime) > 40) {

--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
@@ -67,7 +67,7 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
      */
     public void onStart() {
         // The service has connected, but data may have changed since we were last in the foreground.
-        // Get the session stored in shared preferences stored by {@link #onStop} if its valid,
+        // Get the session stored in shared preferences stored by {@link #onStop} if it's valid,
         // otherwise get the last session currently running.
         if (mActivity.getTermuxService() != null) {
             setCurrentSession(getCurrentStoredSessionOrLast());
@@ -148,7 +148,7 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
         int index = service.getIndexOfSession(finishedSession);
 
         // For plugin commands that expect the result back, we should immediately close the session
-        // and send the result back instead of waiting fo the user to press enter.
+        // and send the result back instead of waiting for the user to press enter.
         // The plugin can handle/show errors itself.
         boolean isPluginExecutionCommandWithPendingResult = false;
         TermuxSession termuxSession = service.getTermuxSession(index);

--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
@@ -202,7 +202,7 @@ public class TermuxTerminalViewClient extends TermuxTerminalViewClientBase {
             if (!KeyboardUtils.areDisableSoftKeyboardFlagsSet(mActivity))
                 KeyboardUtils.showSoftKeyboard(mActivity, mActivity.getTerminalView());
             else
-                Logger.logVerbose(LOG_TAG, "Not showing soft keyboard onSingleTapUp since its disabled");
+                Logger.logVerbose(LOG_TAG, "Not showing soft keyboard onSingleTapUp since it's disabled");
         }
     }
 
@@ -571,7 +571,7 @@ public class TermuxTerminalViewClient extends TermuxTerminalViewClientBase {
         // Requesting terminal view focus is necessary regardless of if soft keyboard is to be
         // disabled or hidden at startup, otherwise if hardware keyboard is attached and user
         // starts typing on hardware keyboard without tapping on the terminal first, then a colour
-        // tint will be added to the terminal as highlight for the focussed view. Test with a light
+        // tint will be added to the terminal as highlight for the focused view. Test with a light
         // theme. For android 8.+, the "defaultFocusHighlightEnabled" attribute is also set to false
         // in TerminalView layout to fix the issue.
 

--- a/terminal-emulator/src/main/java/com/termux/terminal/Logger.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/Logger.java
@@ -63,13 +63,10 @@ public class Logger {
 
         String stackTraceString = null;
 
-        try {
-            StringWriter errors = new StringWriter();
-            PrintWriter pw = new PrintWriter(errors);
+        try (StringWriter errors = new StringWriter();
+             PrintWriter pw = new PrintWriter(errors)) {
             throwable.printStackTrace(pw);
-            pw.close();
             stackTraceString = errors.toString();
-            errors.close();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -430,8 +430,8 @@ public final class TerminalBuffer {
     }
 
     /**
-     * Block set characters. All characters must be within the bounds of the screen, or else and
-     * InvalidParemeterException will be thrown. Typically this is called with a "val" argument of 32 to clear a block
+     * Block set characters. All characters must be within the bounds of the screen, or else an
+     * IllegalArgumentException will be thrown. Typically this is called with a "val" argument of 32 to clear a block
      * of characters.
      */
     public void blockSet(int sx, int sy, int w, int h, int val, long style) {

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
@@ -109,7 +109,7 @@ public final class TerminalColorScheme {
      * If the "cursor" color is not set by user, we need to decide on the appropriate color that will
      * be visible on the current terminal background. White will not be visible on light backgrounds
      * and black won't be visible on dark backgrounds. So we find the perceived brightness of the
-     * background color and if its below the threshold (too dark), we use white cursor and if its
+     * background color and if it's below the threshold (too dark), we use white cursor and if it's
      * above (too bright), we use black cursor.
      */
     public void setCursorColorForBackground() {

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -1190,7 +1190,7 @@ public final class TerminalView extends View {
      * for changes to take effect if not disabling.
      *
      * @param blinkRate The value to set.
-     * @return Returns {@code true} if setting blinker rate was successfully set, otherwise [@code false}.
+     * @return Returns {@code true} if setting blinker rate was successfully set, otherwise {@code false}.
      */
     public synchronized boolean setTerminalCursorBlinkerRate(int blinkRate) {
         boolean result;

--- a/termux-shared/src/main/java/com/termux/shared/activities/ReportActivity.java
+++ b/termux-shared/src/main/java/com/termux/shared/activities/ReportActivity.java
@@ -407,7 +407,7 @@ public class ReportActivity extends AppCompatActivity {
                 Logger.logErrorExtended(LOG_TAG, error.toString());
             }
         } else {
-            Logger.logError(LOG_TAG, "Not deleting " + ReportInfo.class.getSimpleName() + " serialized object file at path \"" + reportInfoFilePath + "\" since its not under \"" + reportInfoDirectoryPath + "\"");
+            Logger.logError(LOG_TAG, "Not deleting " + ReportInfo.class.getSimpleName() + " serialized object file at path \"" + reportInfoFilePath + "\" since it's not under \"" + reportInfoDirectoryPath + "\"");
         }
     }
 

--- a/termux-shared/src/main/java/com/termux/shared/android/AndroidUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/android/AndroidUtils.java
@@ -179,8 +179,9 @@ public class AndroidUtils {
         // multiline values will be ignored
         Pattern propertiesPattern = Pattern.compile("^\\[([^]]+)]: \\[(.+)]$");
 
+        Process process = null;
         try {
-            Process process = new ProcessBuilder()
+            process = new ProcessBuilder()
                 .command("/system/bin/getprop")
                 .redirectErrorStream(true)
                 .start();
@@ -198,12 +199,13 @@ public class AndroidUtils {
                         systemProperties.put(key, value);
                 }
             }
-
             bufferedReader.close();
-            process.destroy();
-
         } catch (IOException e) {
             Logger.logStackTraceWithMessage("Failed to get run \"/system/bin/getprop\" to get system properties.", e);
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
         }
 
         //for (String key : systemProperties.stringPropertyNames()) {

--- a/termux-shared/src/main/java/com/termux/shared/android/AndroidUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/android/AndroidUtils.java
@@ -123,7 +123,7 @@ public class AndroidUtils {
         markdownString.append("\n\n### Software\n");
         appendPropertyToMarkdown(markdownString,"OS_VERSION", getSystemPropertyWithAndroidAPI("os.version"));
         appendPropertyToMarkdown(markdownString, "SDK_INT", Build.VERSION.SDK_INT);
-        // If its a release version
+        // If it's a release version
         if ("REL".equals(Build.VERSION.CODENAME))
             appendPropertyToMarkdown(markdownString, "RELEASE", Build.VERSION.RELEASE);
         else

--- a/termux-shared/src/main/java/com/termux/shared/android/PackageUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/android/PackageUtils.java
@@ -573,7 +573,7 @@ public class PackageUtils {
              * Todo: We may need AndroidManifest queries entries if package is installed but with a different signature on android 11
              * https://developer.android.com/training/package-visibility
              * Need a device that allows (manual) installation of apk with mismatched signature of
-             * sharedUserId apps to test. Currently, if its done, PackageManager just doesn't load
+             * sharedUserId apps to test. Currently, if it's done, PackageManager just doesn't load
              * the package and removes its apk automatically if its installed as a user app instead of system app
              * W/PackageManager: Failed to parse /path/to/com.termux.tasker.apk: Signature mismatch for shared user: SharedUserSetting{xxxxxxx com.termux/10xxx}
              */

--- a/termux-shared/src/main/java/com/termux/shared/android/PackageUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/android/PackageUtils.java
@@ -602,11 +602,11 @@ public class PackageUtils {
     }
 
     /**
-     * Check if the current user is the primary user. This is done by checking if the the serial
+     * Check if the current user is the primary user. This is done by checking if the serial
      * number for the current user equals 0.
      *
      * @param context The {@link Context} for operations.
-     * @return Returns {@code true} if the current user is the primary user, otherwise [@code false}.
+     * @return Returns {@code true} if the current user is the primary user, otherwise {@code false}.
      */
     @RequiresApi(api = Build.VERSION_CODES.N)
     public static boolean isCurrentUserThePrimaryUser(@NonNull Context context) {

--- a/termux-shared/src/main/java/com/termux/shared/android/PermissionUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/android/PermissionUtils.java
@@ -230,8 +230,8 @@ public class PermissionUtils {
 
     /**
      * Check if legacy or manage external storage permissions has been granted. If
-     * {@link #isLegacyExternalStoragePossible(Context)} returns {@code true}, them it will be
-     * checked if app has has been granted {@link Manifest.permission#READ_EXTERNAL_STORAGE} and
+     * {@link #isLegacyExternalStoragePossible(Context)} returns {@code true}, then it will be
+     * checked if app has been granted {@link Manifest.permission#READ_EXTERNAL_STORAGE} and
      * {@link Manifest.permission#WRITE_EXTERNAL_STORAGE} permissions, otherwise it will be checked
      * if app has been granted the {@link Manifest.permission#MANAGE_EXTERNAL_STORAGE} permission.
      *

--- a/termux-shared/src/main/java/com/termux/shared/data/DataUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/data/DataUtils.java
@@ -243,12 +243,10 @@ public class DataUtils {
     /** Get size of a serializable object. */
     public static long getSerializedSize(Serializable object) {
         if (object == null) return 0;
-        try {
-            ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
-            ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteOutputStream);
+        try (ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteOutputStream)) {
             objectOutputStream.writeObject(object);
             objectOutputStream.flush();
-            objectOutputStream.close();
             return byteOutputStream.toByteArray().length;
         } catch (Exception e) {
             return -1;

--- a/termux-shared/src/main/java/com/termux/shared/data/IntentUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/data/IntentUtils.java
@@ -14,7 +14,7 @@ public class IntentUtils {
 
 
     /**
-     * Get a {@link String} extra from an {@link Intent} if its not {@code null} or empty.
+     * Get a {@link String} extra from an {@link Intent} if it's not {@code null} or empty.
      *
      * @param intent The {@link Intent} to get the extra from.
      * @param key The {@link String} key name.
@@ -31,7 +31,7 @@ public class IntentUtils {
     }
 
     /**
-     * Get a {@link String} extra from an {@link Intent} if its not {@code null} or empty.
+     * Get a {@link String} extra from an {@link Intent} if it's not {@code null} or empty.
      *
      * @param intent The {@link Intent} to get the extra from.
      * @param key The {@link String} key name.
@@ -50,7 +50,7 @@ public class IntentUtils {
     }
 
     /**
-     * Get an {@link Integer} from an {@link Intent} stored as a {@link String} extra if its not
+     * Get an {@link Integer} from an {@link Intent} stored as a {@link String} extra if it's not
      * {@code null} or empty.
      *
      * @param intent The {@link Intent} to get the extra from.
@@ -75,7 +75,7 @@ public class IntentUtils {
 
 
     /**
-     * Get a {@link String[]} extra from an {@link Intent} if its not {@code null} or empty.
+     * Get a {@link String[]} extra from an {@link Intent} if it's not {@code null} or empty.
      *
      * @param intent The {@link Intent} to get the extra from.
      * @param key The {@link String} key name.
@@ -92,7 +92,7 @@ public class IntentUtils {
     }
 
     /**
-     * Get a {@link String[]} extra from an {@link Intent} if its not {@code null} or empty.
+     * Get a {@link String[]} extra from an {@link Intent} if it's not {@code null} or empty.
      *
      * @param intent The {@link Intent} to get the extra from.
      * @param key The {@link String} key name.

--- a/termux-shared/src/main/java/com/termux/shared/file/FileUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/file/FileUtils.java
@@ -469,7 +469,7 @@ public class FileUtils {
      * @param parentDirPath The optional {@code parent directory path} to restrict operations to.
      *                      This can optionally be {@code null}. It is not canonicalized and only normalized.
      * @param createDirectoryIfMissing The {@code boolean} that decides if directory file
-     *                                 should be created if its missing.
+     *                                 should be created if it's missing.
      * @param permissionsToCheck The 3 character string that contains the "r", "w", "x" or "-" in-order.
      * @param setPermissions The {@code boolean} that decides if permissions are to be
      *                              automatically set defined by {@code permissionsToCheck}.
@@ -728,7 +728,7 @@ public class FileUtils {
      * {@link #createSymlinkFile(String, String, String, boolean, boolean, boolean)}.
      *
      * Dangling symlinks will be allowed.
-     * Symlink destination will be overwritten if it already exists but only if its a symlink.
+     * Symlink destination will be overwritten if it already exists but only if it's a symlink.
      *
      * @param targetFilePath The {@code path} TO which the symlink file will be created.
      * @param destFilePath The {@code path} AT which the symlink file will be created.
@@ -747,7 +747,7 @@ public class FileUtils {
      * {@link #createSymlinkFile(String, String, String, boolean, boolean, boolean)}.
      *
      * Dangling symlinks will be allowed.
-     * Symlink destination will be overwritten if it already exists but only if its a symlink.
+     * Symlink destination will be overwritten if it already exists but only if it's a symlink.
      *
      * @param label The optional label for the symlink file. This can optionally be {@code null}.
      * @param targetFilePath The {@code path} TO which the symlink file will be created.
@@ -847,7 +847,7 @@ public class FileUtils {
      * This function is a wrapper for
      * {@link #copyOrMoveFile(String, String, String, boolean, boolean, int, boolean, boolean)}.
      *
-     * If destination file already exists, then it will be overwritten, but only if its a regular
+     * If destination file already exists, then it will be overwritten, but only if it's a regular
      * file, otherwise an error will be returned.
      *
      * @param label The optional label for file to copy. This can optionally be {@code null}.
@@ -869,7 +869,7 @@ public class FileUtils {
      * This function is a wrapper for
      * {@link #copyOrMoveFile(String, String, String, boolean, boolean, int, boolean, boolean)}.
      *
-     * If destination file already exists, then it will be overwritten, but only if its a regular
+     * If destination file already exists, then it will be overwritten, but only if it's a regular
      * file, otherwise an error will be returned.
      *
      * @param label The optional label for file to move. This can optionally be {@code null}.
@@ -891,7 +891,7 @@ public class FileUtils {
      * This function is a wrapper for
      * {@link #copyOrMoveFile(String, String, String, boolean, boolean, int, boolean, boolean)}.
      *
-     * If destination file already exists, then it will be overwritten, but only if its a directory
+     * If destination file already exists, then it will be overwritten, but only if it's a directory
      * file, otherwise an error will be returned.
      *
      * @param label The optional label for file to copy. This can optionally be {@code null}.
@@ -913,7 +913,7 @@ public class FileUtils {
      * This function is a wrapper for
      * {@link #copyOrMoveFile(String, String, String, boolean, boolean, int, boolean, boolean)}.
      *
-     * If destination file already exists, then it will be overwritten, but only if its a directory
+     * If destination file already exists, then it will be overwritten, but only if it's a directory
      * file, otherwise an error will be returned.
      *
      * @param label The optional label for file to move. This can optionally be {@code null}.
@@ -935,7 +935,7 @@ public class FileUtils {
      * This function is a wrapper for
      * {@link #copyOrMoveFile(String, String, String, boolean, boolean, int, boolean, boolean)}.
      *
-     * If destination file already exists, then it will be overwritten, but only if its a symlink
+     * If destination file already exists, then it will be overwritten, but only if it's a symlink
      * file, otherwise an error will be returned.
      *
      * @param label The optional label for file to copy. This can optionally be {@code null}.
@@ -957,7 +957,7 @@ public class FileUtils {
      * This function is a wrapper for
      * {@link #copyOrMoveFile(String, String, String, boolean, boolean, int, boolean, boolean)}.
      *
-     * If destination file already exists, then it will be overwritten, but only if its a symlink
+     * If destination file already exists, then it will be overwritten, but only if it's a symlink
      * file, otherwise an error will be returned.
      *
      * @param label The optional label for file to move. This can optionally be {@code null}.
@@ -979,7 +979,7 @@ public class FileUtils {
      * This function is a wrapper for
      * {@link #copyOrMoveFile(String, String, String, boolean, boolean, int, boolean, boolean)}.
      *
-     * If destination file already exists, then it will be overwritten, but only if its the same file
+     * If destination file already exists, then it will be overwritten, but only if it's the same file
      * type as the source, otherwise an error will be returned.
      *
      * @param label The optional label for file to copy. This can optionally be {@code null}.
@@ -1001,7 +1001,7 @@ public class FileUtils {
      * This function is a wrapper for
      * {@link #copyOrMoveFile(String, String, String, boolean, boolean, int, boolean, boolean)}.
      *
-     * If destination file already exists, then it will be overwritten, but only if its the same file
+     * If destination file already exists, then it will be overwritten, but only if it's the same file
      * type as the source, otherwise an error will be returned.
      *
      * @param label The optional label for file to move. This can optionally be {@code null}.
@@ -1690,8 +1690,8 @@ public class FileUtils {
         } catch (Exception e) {
             return FileUtilsErrno.ERRNO_WRITING_TEXT_TO_FILE_FAILED_WITH_EXCEPTION.getError(e, label + "file", filePath, e.getMessage());
         } finally {
-            closeCloseable(fileOutputStream);
             closeCloseable(bufferedWriter);
+            closeCloseable(fileOutputStream);
         }
 
         return null;
@@ -1729,8 +1729,8 @@ public class FileUtils {
         } catch (Exception e) {
             return FileUtilsErrno.ERRNO_WRITING_SERIALIZABLE_OBJECT_TO_FILE_FAILED_WITH_EXCEPTION.getError(e, label + "file", filePath, e.getMessage());
         } finally {
-            closeCloseable(fileOutputStream);
             closeCloseable(objectOutputStream);
+            closeCloseable(fileOutputStream);
         }
 
         return null;

--- a/termux-shared/src/main/java/com/termux/shared/interact/ShareUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/interact/ShareUtils.java
@@ -120,7 +120,7 @@ public class ShareUtils {
 
     /**
      * Wrapper for {@link #getTextFromClipboard(Context, boolean)} that returns primary text {@link String}
-     * if its set and not empty.
+     * if it's set and not empty.
      */
     @Nullable
     public static String getTextStringFromClipboardIfSet(Context context, boolean coerceToText) {

--- a/termux-shared/src/main/java/com/termux/shared/logger/Logger.java
+++ b/termux-shared/src/main/java/com/termux/shared/logger/Logger.java
@@ -310,13 +310,10 @@ public class Logger {
 
         String stackTraceString = null;
 
-        try {
-            StringWriter errors = new StringWriter();
-            PrintWriter pw = new PrintWriter(errors);
+        try (StringWriter errors = new StringWriter();
+             PrintWriter pw = new PrintWriter(errors)) {
             throwable.printStackTrace(pw);
-            pw.close();
             stackTraceString = errors.toString();
-            errors.close();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/termux-shared/src/main/java/com/termux/shared/models/ReportInfo.java
+++ b/termux-shared/src/main/java/com/termux/shared/models/ReportInfo.java
@@ -20,7 +20,7 @@ public class ReportInfo implements Serializable {
      * `java.io.InvalidClassException: <class_name>; local class incompatible`
      *
      * The `@Keep` annotation is necessary to prevent the field from being removed by proguard when
-     * app is compiled, even if its kept during library compilation.
+     * app is compiled, even if it's kept during library compilation.
      *
      * **See Also:**
      * - https://docs.oracle.com/javase/8/docs/platform/serialization/spec/version.html#a6678

--- a/termux-shared/src/main/java/com/termux/shared/models/TextIOInfo.java
+++ b/termux-shared/src/main/java/com/termux/shared/models/TextIOInfo.java
@@ -28,7 +28,7 @@ public class TextIOInfo implements Serializable {
      * `java.io.InvalidClassException: <class_name>; local class incompatible`
      *
      * The `@Keep` annotation is necessary to prevent the field from being removed by proguard when
-     * app is compiled, even if its kept during library compilation.
+     * app is compiled, even if it's kept during library compilation.
      *
      * **See Also:**
      * - https://docs.oracle.com/javase/8/docs/platform/serialization/spec/version.html#a6678

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/ILocalSocketManager.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/ILocalSocketManager.java
@@ -58,7 +58,7 @@ public interface ILocalSocketManager {
      * This is called if a {@link LocalServerSocket} connects to the server which has the
      * the server app's user id or root user id. It is the responsibility of the interface
      * implementation to close the client socket with a call to
-     * {@link LocalClientSocket#closeClientSocket(boolean)} once its done processing.
+     * {@link LocalClientSocket#closeClientSocket(boolean)} once it's done processing.
      *
      * The {@link LocalClientSocket#getPeerCred()} can be used to get the {@link PeerCred} object
      * containing info for the connected client/peer.

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/LocalSocketRunConfig.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/LocalSocketRunConfig.java
@@ -25,7 +25,7 @@ public class LocalSocketRunConfig implements Serializable {
      * socket will fail if the server starter app process does not have write and search (execute)
      * permission on the directory in which the socket is created. The client process must have write
      * permission on the socket to connect to it. Other app will not be able to connect to socket
-     * if its created in private app data directory.
+     * if it's created in private app data directory.
      *
      * For an abstract namespace socket, the first byte must be a null `\0` character. Note that on
      * Android 9+, if server app is using `targetSdkVersion` `28`, then other apps will not be able

--- a/termux-shared/src/main/java/com/termux/shared/net/uri/UriUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/uri/UriUtils.java
@@ -36,7 +36,7 @@ public class UriUtils {
 
     /**
      * Get the file basename from a {@link Uri}. The file basename is anything after last forward
-     * slash "/" in the path, or the path itself if its not found.
+     * slash "/" in the path, or the path itself if it's not found.
      *
      * @param uri The {@link Uri} to get basename from.
      * @param withFragment If the {@link Uri} fragment should be included in basename.

--- a/termux-shared/src/main/java/com/termux/shared/shell/StreamGobbler.java
+++ b/termux-shared/src/main/java/com/termux/shared/shell/StreamGobbler.java
@@ -131,7 +131,7 @@ public class StreamGobbler extends Thread {
      * possible to prevent a deadlock from occurring, or Process.waitFor() never
      * returning (as the buffer is full, pausing the native process)</p>
      * Do not use this for concurrent reading for STDOUT and STDERR for the same StringBuilder since
-     * its not synchronized.
+     * it's not synchronized.
      *
      * @param shell Name of the shell
      * @param inputStream InputStream to read from

--- a/termux-shared/src/main/java/com/termux/shared/shell/command/environment/ShellEnvironmentUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/shell/command/environment/ShellEnvironmentUtils.java
@@ -59,7 +59,7 @@ public class ShellEnvironmentUtils {
      * If the {@link ShellEnvironmentVariable#escaped} is set to {@code true}, then
      * {@link ShellEnvironmentVariable#value} will be considered to be a literal value that has
      * already been escaped by the caller, otherwise all the `"`\$` in the value will be escaped
-     * with `a backslash `\`, like `\"`. Note that if `$` is escaped and if its part of variable,
+     * with `a backslash `\`, like `\"`. Note that if `$` is escaped and if it's part of variable,
      * then variable expansion will not happen if `.env` file is sourced.
      *
      * The `\` at the end of a value line means line continuation. Value can contain newline characters.

--- a/termux-shared/src/main/java/com/termux/shared/shell/command/runner/app/AppShell.java
+++ b/termux-shared/src/main/java/com/termux/shared/shell/command/runner/app/AppShell.java
@@ -247,7 +247,7 @@ public final class AppShell {
 
     /**
      * Kill this {@link AppShell} by sending a {@link OsConstants#SIGILL} to its {@link #mProcess}
-     * if its still executing.
+     * if it's still executing.
      *
      * @param context The {@link Context} for operations.
      * @param processResult If set to {@code true}, then the {@link #processAppShellResult(AppShell, ExecutionCommand)}
@@ -319,7 +319,7 @@ public final class AppShell {
             appShell.mAppShellClient.onAppShellExited(appShell);
         } else {
             // If a callback is not set and execution command didn't fail, then we set success state now
-            // Otherwise, the callback host can set it himself when its done with the appShell
+            // Otherwise, the callback host can set it himself when it's done with the appShell
             if (!executionCommand.isStateFailed())
                 executionCommand.setState(ExecutionCommand.ExecutionState.SUCCESS);
         }

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
@@ -1056,14 +1056,14 @@ public final class TermuxConstants {
 
             /**
              * The value for {@link #EXTRA_SESSION_ACTION} extra that will set the new session as
-             * the current session and will start {@link TERMUX_ACTIVITY} if its not running to bring
+             * the current session and will start {@link TERMUX_ACTIVITY} if it's not running to bring
              * the new session to foreground.
              */
             public static final int VALUE_EXTRA_SESSION_ACTION_SWITCH_TO_NEW_SESSION_AND_OPEN_ACTIVITY = 0;
 
             /**
              * The value for {@link #EXTRA_SESSION_ACTION} extra that will keep any existing session
-             * as the current session and will start {@link TERMUX_ACTIVITY} if its not running to
+             * as the current session and will start {@link TERMUX_ACTIVITY} if it's not running to
              * bring the existing session to foreground. The new session will be added to the left
              * sidebar in the sessions list.
              */
@@ -1071,7 +1071,7 @@ public final class TermuxConstants {
 
             /**
              * The value for {@link #EXTRA_SESSION_ACTION} extra that will set the new session as
-             * the current session but will not start {@link TERMUX_ACTIVITY} if its not running
+             * the current session but will not start {@link TERMUX_ACTIVITY} if it's not running
              * and session(s) will be seen in Termux notification and can be clicked to bring new
              * session to foreground. If the {@link TERMUX_ACTIVITY} is already running, then this
              * will behave like {@link #VALUE_EXTRA_SESSION_ACTION_KEEP_CURRENT_SESSION_AND_OPEN_ACTIVITY}.
@@ -1080,7 +1080,7 @@ public final class TermuxConstants {
 
             /**
              * The value for {@link #EXTRA_SESSION_ACTION} extra that will keep any existing session
-             * as the current session but will not start {@link TERMUX_ACTIVITY} if its not running
+             * as the current session but will not start {@link TERMUX_ACTIVITY} if it's not running
              * and session(s) will be seen in Termux notification and can be clicked to bring
              * existing session to foreground. If the {@link TERMUX_ACTIVITY} is already running,
              * then this will behave like {@link #VALUE_EXTRA_SESSION_ACTION_KEEP_CURRENT_SESSION_AND_OPEN_ACTIVITY}.

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
@@ -952,7 +952,7 @@ public final class TermuxConstants {
 
             /** Intent action to make termux reload its termux session styling */
             public static final String ACTION_RELOAD_STYLE = TermuxConstants.TERMUX_PACKAGE_NAME + ".app.reload_style"; // Default: "com.termux.app.reload_style"
-            /** Intent {@code String} extra for what to reload for the TERMUX_ACTIVITY.ACTION_RELOAD_STYLE intent. This has been deperecated. */
+            /** Intent {@code String} extra for what to reload for the TERMUX_ACTIVITY.ACTION_RELOAD_STYLE intent. This has been deprecated. */
             @Deprecated
             public static final String EXTRA_RELOAD_STYLE = TermuxConstants.TERMUX_PACKAGE_NAME + ".app.reload_style"; // Default: "com.termux.app.reload_style"
 

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxUtils.java
@@ -425,7 +425,7 @@ public class TermuxUtils {
      *
      * @param currentPackageContext The context of current package.
      * @param returnTermuxPackageInfoToo If set to {@code true}, then will return info of the
-     * {@link TermuxConstants#TERMUX_PACKAGE_NAME} package as well if its different from current package.
+     * {@link TermuxConstants#TERMUX_PACKAGE_NAME} package as well if it's different from current package.
      * @return Returns the markdown {@link String}.
      */
     public static String getAppInfoMarkdownString(final Context currentPackageContext, final boolean returnTermuxPackageInfoToo) {

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxUtils.java
@@ -184,7 +184,7 @@ public class TermuxUtils {
      * Check if Termux app is installed and accessible. This can only be used by apps that share
      * `sharedUserId` with the Termux app.
      *
-     * This is done by checking if first checking if app is installed and enabled and then if
+     * This is done by first checking if app is installed and enabled and then if
      * {@code currentPackageContext} can be used to get the {@link Context} of the app with
      * {@link TermuxConstants#TERMUX_PACKAGE_NAME} and then if
      * {@link TermuxConstants#TERMUX_PREFIX_DIR_PATH} exists and has
@@ -242,7 +242,7 @@ public class TermuxUtils {
      * Get a field value from a class of the Termux app APK installed on the device.
      * This can only be used by apps that share `sharedUserId` with the Termux app.
      *
-     * This is done by getting first getting termux app package context and then getting in class
+     * This is done by first getting termux app package context and then getting in class
      * loader (instead of current app's) that contains termux app class info, and then using that to
      * load the required class and then getting required field from it.
      *

--- a/termux-shared/src/main/java/com/termux/shared/termux/extrakeys/ExtraKeysInfo.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/extrakeys/ExtraKeysInfo.java
@@ -67,12 +67,12 @@ import org.json.JSONObject;
  * Aliases are also allowed for the keys that you can pass as {@code extraKeyAliasMap}. Check
  * {@link ExtraKeysConstants#CONTROL_CHARS_ALIASES}.
  *
- * Its up to the {@link ExtraKeysView.IExtraKeysView} client on how to handle individual key values
+ * It's up to the {@link ExtraKeysView.IExtraKeysView} client on how to handle individual key values
  * of an {@link ExtraKeyButton}. They are sent as is via
  * {@link ExtraKeysView.IExtraKeysView#onExtraKeyButtonClick(View, ExtraKeyButton, MaterialButton)}. The
  * {@link TerminalExtraKeys} which is an implementation of the interface,
  * checks if the key is one of {@link ExtraKeysConstants#PRIMARY_KEY_CODES_FOR_STRINGS} and generates
- * a {@link android.view.KeyEvent} for it, and if its not, then converts the key to code points by
+ * a {@link android.view.KeyEvent} for it, and if it's not, then converts the key to code points by
  * calling {@link CharSequence#codePoints()} and passes them to the terminal as literal strings.
  *
  * Examples:

--- a/termux-shared/src/main/java/com/termux/shared/termux/extrakeys/ExtraKeysView.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/extrakeys/ExtraKeysView.java
@@ -95,7 +95,7 @@ public final class ExtraKeysView extends GridLayout {
         /**
          * This is called by {@link ExtraKeysView} when a button is clicked so that the client
          * can perform any haptic feedback. This is only called in the {@link MaterialButton.OnClickListener}
-         * and not for every repeat. Its also called for {@link #mSpecialButtons}.
+         * and not for every repeat. It's also called for {@link #mSpecialButtons}.
          *
          * @param view The view that was clicked.
          * @param buttonInfo The {@link ExtraKeyButton} for the button that was clicked.
@@ -158,7 +158,7 @@ public final class ExtraKeysView extends GridLayout {
 
 
     /**
-     * The list of keys for which auto repeat of key should be triggered if its extra keys button
+     * The list of keys for which auto repeat of key should be triggered if it's extra keys button
      * is long pressed. This is done by calling {@link IExtraKeysView#onExtraKeyButtonClick(View, ExtraKeyButton, MaterialButton)}
      * every {@link #mLongPressRepeatDelay} seconds after {@link #mLongPressTimeout} has passed.
      * The default keys are defined by {@link ExtraKeysConstants#PRIMARY_REPETITIVE_KEYS}.
@@ -168,12 +168,12 @@ public final class ExtraKeysView extends GridLayout {
 
     /** The text color for the extra keys button. Defaults to {@link #DEFAULT_BUTTON_TEXT_COLOR}. */
     protected int mButtonTextColor;
-    /** The text color for the extra keys button when its active.
+    /** The text color for the extra keys button when it's active.
      * Defaults to {@link #DEFAULT_BUTTON_ACTIVE_TEXT_COLOR}. */
     protected int mButtonActiveTextColor;
     /** The background color for the extra keys button. Defaults to {@link #DEFAULT_BUTTON_BACKGROUND_COLOR}. */
     protected int mButtonBackgroundColor;
-    /** The background color for the extra keys button when its active. Defaults to
+    /** The background color for the extra keys button when it's active. Defaults to
      * {@link #DEFAULT_BUTTON_ACTIVE_BACKGROUND_COLOR}. */
     protected int mButtonActiveBackgroundColor;
 

--- a/termux-shared/src/main/java/com/termux/shared/termux/extrakeys/ExtraKeysView.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/extrakeys/ExtraKeysView.java
@@ -94,7 +94,7 @@ public final class ExtraKeysView extends GridLayout {
 
         /**
          * This is called by {@link ExtraKeysView} when a button is clicked so that the client
-         * can perform any hepatic feedback. This is only called in the {@link MaterialButton.OnClickListener}
+         * can perform any haptic feedback. This is only called in the {@link MaterialButton.OnClickListener}
          * and not for every repeat. Its also called for {@link #mSpecialButtons}.
          *
          * @param view The view that was clicked.

--- a/termux-shared/src/main/java/com/termux/shared/termux/file/TermuxFileUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/file/TermuxFileUtils.java
@@ -150,7 +150,7 @@ public class TermuxFileUtils {
      * @param label The optional label for the directory file. This can optionally be {@code null}.
      * @param filePath The {@code path} for file to validate or create. Symlinks will not be followed.
      * @param createDirectoryIfMissing The {@code boolean} that decides if directory file
-     *                                 should be created if its missing.
+     *                                 should be created if it's missing.
      * @param setPermissions The {@code boolean} that decides if permissions are to be
      *                              automatically set defined by {@code permissionsToCheck}.
      * @param setMissingPermissionsOnly The {@code boolean} that decides if only missing permissions
@@ -248,7 +248,7 @@ public class TermuxFileUtils {
      *
      * @param context The {@link Context} for operations.
      * @param createDirectoryIfMissing The {@code boolean} that decides if directory file
-     *                                 should be created if its missing.
+     *                                 should be created if it's missing.
      * @param setMissingPermissions The {@code boolean} that decides if permissions are to be
      *                              automatically set.
      * @return Returns the {@code error} if path is not a directory file, failed to create it,
@@ -278,7 +278,7 @@ public class TermuxFileUtils {
      * not been installed or the bootstrap setup has not been run or if it was deleted by the user.
      *
      * @param createDirectoryIfMissing The {@code boolean} that decides if directory file
-     *                                 should be created if its missing.
+     *                                 should be created if it's missing.
      * @param setMissingPermissions The {@code boolean} that decides if permissions are to be
      *                              automatically set.
      * @return Returns the {@code error} if path is not a directory file, failed to create it,
@@ -296,7 +296,7 @@ public class TermuxFileUtils {
      * {@link FileUtils#APP_WORKING_DIRECTORY_PERMISSIONS} permissions.
      *
      * @param createDirectoryIfMissing The {@code boolean} that decides if directory file
-     *                                 should be created if its missing.
+     *                                 should be created if it's missing.
      * @param setMissingPermissions The {@code boolean} that decides if permissions are to be
      *                              automatically set.
      * @return Returns the {@code error} if path is not a directory file, failed to create it,
@@ -314,7 +314,7 @@ public class TermuxFileUtils {
      * {@link FileUtils#APP_WORKING_DIRECTORY_PERMISSIONS} permissions.
      *
      * @param createDirectoryIfMissing The {@code boolean} that decides if directory file
-     *                                 should be created if its missing.
+     *                                 should be created if it's missing.
      * @param setMissingPermissions The {@code boolean} that decides if permissions are to be
      *                              automatically set.
      * @return Returns the {@code error} if path is not a directory file, failed to create it,

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
@@ -77,7 +77,7 @@ public abstract class TermuxSharedProperties {
      *
      * @param key The key to read.
      * @param def The default value.
-     * @param cached If {@code true}, then the value is returned from the the {@link Properties} in-memory cache.
+     * @param cached If {@code true}, then the value is returned from the {@link Properties} in-memory cache.
      *               Otherwise the {@link Properties} object is read directly from the file
      *               and value is returned from it against the key.
      * @return Returns the {@link String} object. This will be {@code null} if key is not found.
@@ -91,7 +91,7 @@ public abstract class TermuxSharedProperties {
      * the {@link #mPropertiesFile} file.
      *
      * @param key The key to read.
-     * @param cached If {@code true}, then the value is checked from the the {@link Properties} in-memory cache.
+     * @param cached If {@code true}, then the value is checked from the {@link Properties} in-memory cache.
      *               Otherwise the {@link Properties} object is read directly from the file
      *               and value is checked from it.
      * @param logErrorOnInvalidValue If {@code true}, then an error will be logged if key value
@@ -109,7 +109,7 @@ public abstract class TermuxSharedProperties {
      * the {@link #mPropertiesFile} file.
      *
      * @param key The key to read.
-     * @param cached If {@code true}, then the value is checked from the the {@link Properties} in-memory cache.
+     * @param cached If {@code true}, then the value is checked from the {@link Properties} in-memory cache.
      *               Otherwise the {@link Properties} object is read directly from the file
      *               and value is checked from it.
      * @param logErrorOnInvalidValue If {@code true}, then an error will be logged if key value

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
@@ -337,7 +337,7 @@ public abstract class TermuxSharedProperties {
     }
 
     /**
-     * Returns the int for the value if its not null and is between
+     * Returns the int for the value if it's not null and is between
      * {@link TermuxPropertyConstants#IVALUE_DELETE_TMPDIR_FILES_OLDER_THAN_X_DAYS_ON_EXIT_MIN} and
      * {@link TermuxPropertyConstants#IVALUE_DELETE_TMPDIR_FILES_OLDER_THAN_X_DAYS_ON_EXIT_MAX},
      * otherwise returns {@link TermuxPropertyConstants#DEFAULT_IVALUE_DELETE_TMPDIR_FILES_OLDER_THAN_X_DAYS_ON_EXIT}.
@@ -355,7 +355,7 @@ public abstract class TermuxSharedProperties {
     }
 
     /**
-     * Returns the int for the value if its not null and is between
+     * Returns the int for the value if it's not null and is between
      * {@link TermuxPropertyConstants#IVALUE_TERMINAL_CURSOR_BLINK_RATE_MIN} and
      * {@link TermuxPropertyConstants#IVALUE_TERMINAL_CURSOR_BLINK_RATE_MAX},
      * otherwise returns {@link TermuxPropertyConstants#DEFAULT_IVALUE_TERMINAL_CURSOR_BLINK_RATE}.
@@ -385,7 +385,7 @@ public abstract class TermuxSharedProperties {
     }
 
     /**
-     * Returns the int for the value if its not null and is between
+     * Returns the int for the value if it's not null and is between
      * {@link TermuxPropertyConstants#IVALUE_TERMINAL_MARGIN_HORIZONTAL_MIN} and
      * {@link TermuxPropertyConstants#IVALUE_TERMINAL_MARGIN_HORIZONTAL_MAX},
      * otherwise returns {@link TermuxPropertyConstants#DEFAULT_IVALUE_TERMINAL_MARGIN_HORIZONTAL}.
@@ -403,7 +403,7 @@ public abstract class TermuxSharedProperties {
     }
 
     /**
-     * Returns the int for the value if its not null and is between
+     * Returns the int for the value if it's not null and is between
      * {@link TermuxPropertyConstants#IVALUE_TERMINAL_MARGIN_VERTICAL_MIN} and
      * {@link TermuxPropertyConstants#IVALUE_TERMINAL_MARGIN_VERTICAL_MAX},
      * otherwise returns {@link TermuxPropertyConstants#DEFAULT_IVALUE_TERMINAL_MARGIN_VERTICAL}.
@@ -421,7 +421,7 @@ public abstract class TermuxSharedProperties {
     }
 
     /**
-     * Returns the int for the value if its not null and is between
+     * Returns the int for the value if it's not null and is between
      * {@link TermuxPropertyConstants#IVALUE_TERMINAL_TRANSCRIPT_ROWS_MIN} and
      * {@link TermuxPropertyConstants#IVALUE_TERMINAL_TRANSCRIPT_ROWS_MAX},
      * otherwise returns {@link TermuxPropertyConstants#DEFAULT_IVALUE_TERMINAL_TRANSCRIPT_ROWS}.
@@ -439,7 +439,7 @@ public abstract class TermuxSharedProperties {
     }
 
     /**
-     * Returns the int for the value if its not null and is between
+     * Returns the int for the value if it's not null and is between
      * {@link TermuxPropertyConstants#IVALUE_TERMINAL_TOOLBAR_HEIGHT_SCALE_FACTOR_MIN} and
      * {@link TermuxPropertyConstants#IVALUE_TERMINAL_TOOLBAR_HEIGHT_SCALE_FACTOR_MAX},
      * otherwise returns {@link TermuxPropertyConstants#DEFAULT_IVALUE_TERMINAL_TOOLBAR_HEIGHT_SCALE_FACTOR}.

--- a/termux-shared/src/main/java/com/termux/shared/termux/shell/am/TermuxAmSocketServer.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/shell/am/TermuxAmSocketServer.java
@@ -79,14 +79,14 @@ public class TermuxAmSocketServer {
         // Start termux-am-socket server if enabled by user
         boolean enabled = false;
         if (TermuxAppSharedProperties.getProperties().shouldRunTermuxAmSocketServer()) {
-            Logger.logDebug(LOG_TAG, "Starting " + TITLE + " socket server since its enabled");
+            Logger.logDebug(LOG_TAG, "Starting " + TITLE + " socket server since it's enabled");
             start(context);
             if (termuxAmSocketServer != null && termuxAmSocketServer.isRunning()) {
                 enabled = true;
                 Logger.logDebug(LOG_TAG, TITLE + " socket server successfully started");
             }
         } else {
-            Logger.logDebug(LOG_TAG, "Not starting " + TITLE + " socket server since its not enabled");
+            Logger.logDebug(LOG_TAG, "Not starting " + TITLE + " socket server since it's not enabled");
         }
 
         // Once termux-app has started, the server state must not be changed since the variable is

--- a/termux-shared/src/main/java/com/termux/shared/termux/shell/command/runner/terminal/TermuxSession.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/shell/command/runner/terminal/TermuxSession.java
@@ -69,7 +69,7 @@ public class TermuxSession {
      *                        available in the {@link TermuxSessionClient#onTermuxSessionExited(TermuxSession)}
      *                        callback will be set to the {@link TerminalSession} transcript. The session
      *                        transcript will contain both stdout and stderr combined, basically
-     *                        anything sent to the the pseudo terminal /dev/pts, including PS1 prefixes.
+     *                        anything sent to the pseudo terminal /dev/pts, including PS1 prefixes.
      *                        Set this to {@code true} only if the session transcript is required,
      *                        since this requires extra processing to get it.
      * @return Returns the {@link TermuxSession}. This will be {@code null} if failed to start the execution command.

--- a/termux-shared/src/main/java/com/termux/shared/termux/shell/command/runner/terminal/TermuxSession.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/shell/command/runner/terminal/TermuxSession.java
@@ -104,9 +104,9 @@ public class TermuxSession {
 
             if (executionCommand.executable == null) {
                 // Fall back to system shell as last resort:
-                // Do not start a login shell since ~/.profile may cause startup failure if its invalid.
-                // /system/bin/sh is provided by mksh (not toybox) and does load .mkshrc but for android its set
-                // to /system/etc/mkshrc even though its default is ~/.mkshrc.
+                // Do not start a login shell since ~/.profile may cause startup failure if it's invalid.
+                // /system/bin/sh is provided by mksh (not toybox) and does load .mkshrc but for android it's set
+                // to /system/etc/mkshrc even though it's default is ~/.mkshrc.
                 // So /system/etc/mkshrc must still be valid for failsafe session to start properly.
                 // https://cs.android.com/android/platform/superproject/+/android-11.0.0_r3:external/mksh/src/main.c;l=663
                 // https://cs.android.com/android/platform/superproject/+/android-11.0.0_r3:external/mksh/src/main.c;l=41
@@ -203,7 +203,7 @@ public class TermuxSession {
 
     /**
      * Kill this {@link TermuxSession} by sending a {@link OsConstants#SIGILL} to its {@link #mTerminalSession}
-     * if its still executing.
+     * if it's still executing.
      *
      * @param context The {@link Context} for operations.
      * @param processResult If set to {@code true}, then the {@link #processTermuxSessionResult(TermuxSession, ExecutionCommand)}
@@ -266,7 +266,7 @@ public class TermuxSession {
             termuxSession.mTermuxSessionClient.onTermuxSessionExited(termuxSession);
         } else {
             // If a callback is not set and execution command didn't fail, then we set success state now
-            // Otherwise, the callback host can set it himself when its done with the termuxSession
+            // Otherwise, the callback host can set it himself when it's done with the termuxSession
             if (!executionCommand.isStateFailed())
                 executionCommand.setState(ExecutionCommand.ExecutionState.SUCCESS);
         }

--- a/termux-shared/src/main/java/com/termux/shared/view/KeyboardUtils.java
+++ b/termux-shared/src/main/java/com/termux/shared/view/KeyboardUtils.java
@@ -181,7 +181,7 @@ public class KeyboardUtils {
              * WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE which pushes up the view when
              * keyboard is opened instead of the keyboard opening on top of the view (hiding stuff).
              * If the "Show soft keyboard" toggle was disabled, then this resizing shouldn't happen.
-             * But it seems resizing does happen, but keyboard is never opened since its not supposed to.
+             * But it seems resizing does happen, but keyboard is never opened since it's not supposed to.
              * https://github.com/termux/termux-app/issues/1995#issuecomment-837080079
              */
             // If soft keyboard is disabled by user only if hardware keyboard is connected


### PR DESCRIPTION
## Summary

This PR fixes multiple code quality issues across the termux-app codebase:

### Typo Fixes (12 files)
- Fixed 'is is' → 'is' in TermuxInstaller.java
- Fixed 'InvalidParemeterException' → 'IllegalArgumentException' in TerminalBuffer.java
- Fixed 'or else and' → 'or else an' in TerminalBuffer.java
- Fixed 'hepatic' → 'haptic' in ExtraKeysView.java
- Fixed 'deperecated' → 'deprecated' in TermuxConstants.java
- Fixed 'if the the' → 'if the' in PackageUtils.java
- Fixed 4x 'from the the' → 'from the' in TermuxSharedProperties.java
- Fixed 'to the the' → 'to the' in TermuxSession.java
- Fixed duplicated phrases in TermuxUtils.java
- Fixed Javadoc tags [@code → {@code in PackageUtils.java and TerminalView.java

### Grammar Fixes (31 files)
- Fixed 'its' → 'it's' (contraction of 'it is') across 40+ locations
- Fixed 'has has' → 'has' in PermissionUtils.java
- Fixed 'them' → 'then' in PermissionUtils.java
- Fixed 'focussed' → 'focused' in TermuxTerminalViewClient.java
- Fixed 'fo' → 'for' in TermuxTerminalSessionActivityClient.java
- Fixed missing 'we' in TermuxService.java comment

### Resource Management Fixes (4 files)
- Fixed unclosed StringWriter/PrintWriter in Logger.java (terminal-emulator) using try-with-resources
- Fixed unclosed StringWriter/PrintWriter in Logger.java (shared) using try-with-resources
- Fixed unclosed Process/InputStream in AndroidUtils.java with proper finally block
- Fixed unclosed ByteArrayOutputStream/ObjectOutputStream in DataUtils.java using try-with-resources
- Fixed resource close order in FileUtils.java (close wrapper before underlying stream)

All changes follow the project's Conventional Commits spec.