### PR TITLE
Offer Rename / Kill when long pressing a session in the drawer

### DIFF
--- a/app/src/main/java/com/termux/app/terminal/TermuxSessionsListViewController.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxSessionsListViewController.java
@@ -1,6 +1,7 @@
 package com.termux.app.terminal;
 
 import android.annotation.SuppressLint;
+import android.app.AlertDialog;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Typeface;
@@ -16,7 +17,6 @@ import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 
 import com.termux.R;
@@ -127,10 +127,8 @@ public class TermuxSessionsListViewController extends ArrayAdapter<TermuxSession
     private void confirmKillSession(TerminalSession terminalSession) {
         new AlertDialog.Builder(mActivity)
             .setMessage(R.string.title_confirm_kill_session)
-            .setPositiveButton(android.R.string.yes, (dialog, which) -> {
-                terminalSession.finishIfRunning();
-                mActivity.getTermuxTerminalSessionClient().removeFinishedSession(terminalSession);
-            })
+            .setPositiveButton(android.R.string.yes, (dialog, which) ->
+                mActivity.getTermuxTerminalSessionClient().killAndRemoveSession(terminalSession))
             .setNegativeButton(android.R.string.no, null)
             .show();
     }

--- a/app/src/main/java/com/termux/app/terminal/TermuxSessionsListViewController.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxSessionsListViewController.java
@@ -16,6 +16,7 @@ import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 
 import com.termux.R;
@@ -102,8 +103,36 @@ public class TermuxSessionsListViewController extends ArrayAdapter<TermuxSession
     @Override
     public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
         final TermuxSession selectedSession = getItem(position);
-        mActivity.getTermuxTerminalSessionClient().renameSession(selectedSession.getTerminalSession());
+        if (selectedSession == null) return true;
+        final TerminalSession terminalSession = selectedSession.getTerminalSession();
+        if (terminalSession == null) return true;
+
+        // Long pressing used to jump straight to renaming, leaving no way to close a session from
+        // the drawer at all. Offer both actions instead.
+        new AlertDialog.Builder(mActivity)
+            .setItems(new CharSequence[]{
+                mActivity.getString(R.string.action_rename_session),
+                mActivity.getString(R.string.action_kill_session)
+            }, (dialog, which) -> {
+                if (which == 0) {
+                    mActivity.getTermuxTerminalSessionClient().renameSession(terminalSession);
+                } else {
+                    confirmKillSession(terminalSession);
+                }
+            })
+            .show();
         return true;
+    }
+
+    private void confirmKillSession(TerminalSession terminalSession) {
+        new AlertDialog.Builder(mActivity)
+            .setMessage(R.string.title_confirm_kill_session)
+            .setPositiveButton(android.R.string.yes, (dialog, which) -> {
+                terminalSession.finishIfRunning();
+                mActivity.getTermuxTerminalSessionClient().removeFinishedSession(terminalSession);
+            })
+            .setNegativeButton(android.R.string.no, null)
+            .show();
     }
 
 }

--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalSessionActivityClient.java
@@ -35,7 +35,10 @@ import com.termux.terminal.TextStyle;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Properties;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 /** The {@link TerminalSessionClient} implementation that may require an {@link Activity} for its interface methods. */
 public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionClientBase {
@@ -47,6 +50,9 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
     private SoundPool mBellSoundPool;
 
     private int mBellSoundId;
+
+    /** Sessions killed from the drawer, to be removed once they exit. */
+    private final Set<TerminalSession> mSessionsPendingRemoval = Collections.newSetFromMap(new WeakHashMap<>());
 
     private static final String LOG_TAG = "TermuxTerminalSessionActivityClient";
 
@@ -142,6 +148,12 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
         if (service == null || service.wantsToStop()) {
             // The service wants to stop as soon as possible.
             mActivity.finishActivityIfNotFinishing();
+            return;
+        }
+
+        // Killed from the drawer: the removal was deferred until the process actually exited.
+        if (mSessionsPendingRemoval.remove(finishedSession)) {
+            removeFinishedSession(finishedSession);
             return;
         }
 
@@ -428,6 +440,26 @@ public class TermuxTerminalSessionActivityClient extends TermuxTerminalSessionCl
         if (service == null) return null;
 
         return service.getTerminalSessionForHandle(sessionHandle);
+    }
+
+    /**
+     * Kill a session and remove it once it has actually exited.
+     *
+     * {@link TerminalSession#finishIfRunning()} only sends SIGKILL; the process exits
+     * asynchronously and {@link TermuxSession#finish()} ignores a session that is still
+     * running, so removing it in the same breath silently does nothing. Remember the
+     * session instead and remove it from {@link #onSessionFinished(TerminalSession)}.
+     */
+    public void killAndRemoveSession(TerminalSession session) {
+        if (session == null) return;
+
+        if (!session.isRunning()) {
+            removeFinishedSession(session);
+            return;
+        }
+
+        mSessionsPendingRemoval.add(session);
+        session.finishIfRunning();
     }
 
     public void removeFinishedSession(TerminalSession finishedSession) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,9 @@
     <string name="action_reset_terminal">Reset</string>
     <string name="msg_terminal_reset">Terminal reset</string>
 
+    <string name="action_rename_session">Rename session</string>
+    <string name="action_kill_session">Kill session</string>
+    <string name="title_confirm_kill_session">Really kill this session?</string>
     <string name="action_kill_process">Kill process (%d)</string>
     <string name="title_confirm_kill_process">Really kill this session?</string>
 


### PR DESCRIPTION
Long pressing a session in the drawer goes straight to renaming it, so there is no way to close a
session from the drawer at all. Killing one means switching to it first and using the terminal's own
context menu, or typing `exit`.

This makes long press open a two item dialog offering **Rename** and **Kill**. Rename keeps the
existing behaviour; Kill reuses the same confirmation prompt (`title_confirm_kill_session`) before
calling `finishIfRunning()` and removing the finished session, matching what the terminal context
menu already does.

Two strings are added for the menu items and one for the confirmation.

Tested on an Android 16 device and an API 31 emulator: renaming still works, killing removes the
session from the drawer list, and cancelling leaves it running.
