### PR TITLE
Fix the action reference in the Gradle wrapper validation workflow

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: gradle/actions/wrapper-validation@5
+      - uses: gradle/actions/wrapper-validation@v5


### PR DESCRIPTION
`gradle-wrapper-validation.yml` refers to `gradle/actions/wrapper-validation@5`, but `gradle/actions`
publishes its tags as `v5`, `v6` and so on — there is no bare `5` tag. GitHub cannot resolve the
reference, so the job dies with a startup failure before running a single step.

This has been happening on every run since the reference was introduced, including pushes to `master`:

```
2026-08-15  startup_failure  [emoji-vs16-double-width]
2026-08-13  startup_failure  [master]
2026-08-13  startup_failure  [master]
2026-08-12  startup_failure  [docs/fix-spelling]
2026-08-11  startup_failure  [codex/preserve-enter-modifiers]
2026-08-08  startup_failure  [fix/locale-result-sender-selection-fixes]
```

Because the failure happens at startup rather than in a step, the run has no log to open, which makes
it easy to miss — it just shows up as a red cross on every PR.

`dependency-submission.yml` in this repo already uses `gradle/actions/dependency-submission@v5`, so
this change simply matches the working sibling reference.

One character.
