### PR TITLE
Open Termux wiki in an external browser

### DIFF
--- a/app/src/main/java/com/termux/app/activities/HelpActivity.java
+++ b/app/src/main/java/com/termux/app/activities/HelpActivity.java
@@ -63,6 +63,9 @@ public final class HelpActivity extends AppCompatActivity {
             }
         });
         mWebView.loadUrl(TermuxConstants.TERMUX_WIKI_URL);
+        // Anubis prevents Termux wiki from loading in regular WebView, we need to launch an external browser
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(TermuxConstants.TERMUX_WIKI_URL));
+        startActivity(browserIntent);
     }
 
     @Override


### PR DESCRIPTION
Because Anubis prevents wiki page from loading in regular WebView on Android 12