### PR TITLE
fixed: eliminate bottom viewport remainder gap via dynamic line spacing in TerminalRenderer

### DIFF
--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
@@ -27,12 +27,12 @@ public final class TerminalRenderer {
     /** The {@link Paint#getFontSpacing()}. See http://www.fampennings.nl/maarten/android/08numgrid/font.png */
     final int mFontLineSpacing;
     /** The {@link Paint#ascent()}. See http://www.fampennings.nl/maarten/android/08numgrid/font.png */
-
-    public float mDynamicLineSpacing = 0;
-
     private final int mFontAscent;
     /** The {@link #mFontLineSpacing} + {@link #mFontAscent}. */
     final int mFontLineSpacingAndAscent;
+
+    /** Dynamic line spacing to eliminate viewport remainder gap. */
+    float mDynamicLineSpacing = 0;
 
     private final float[] asciiMeasures = new float[127];
 
@@ -211,13 +211,13 @@ public final class TerminalRenderer {
         if (backColor != palette[TextStyle.COLOR_INDEX_BACKGROUND]) {
             // Only draw non-default background.
             mTextPaint.setColor(backColor);
-            float top = mDynamicLineSpacing > 0 ? (y - mDynamicLineSpacing) : (y - mFontLineSpacingAndAscent + mFontAscent);
+            float top = y - getDynamicLineSpacing();
             canvas.drawRect(left, top, right, y, mTextPaint);
         }
 
         if (cursor != 0) {
             mTextPaint.setColor(cursor);
-            float cursorHeight = mDynamicLineSpacing > 0 ? mDynamicLineSpacing : (mFontLineSpacingAndAscent - mFontAscent);
+            float cursorHeight = getDynamicLineSpacing();
             if (cursorStyle == TerminalEmulator.TERMINAL_CURSOR_STYLE_UNDERLINE) cursorHeight /= 4.;
             else if (cursorStyle == TerminalEmulator.TERMINAL_CURSOR_STYLE_BAR) right -= ((right - left) * 3) / 4.;
             canvas.drawRect(left, y - cursorHeight, right, y, mTextPaint);
@@ -255,5 +255,9 @@ public final class TerminalRenderer {
 
     public int getFontLineSpacing() {
         return mFontLineSpacing;
+    }
+
+    public float getDynamicLineSpacing() {
+        return mDynamicLineSpacing > 0 ? mDynamicLineSpacing : mFontLineSpacing;
     }
 }

--- a/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
@@ -27,6 +27,9 @@ public final class TerminalRenderer {
     /** The {@link Paint#getFontSpacing()}. See http://www.fampennings.nl/maarten/android/08numgrid/font.png */
     final int mFontLineSpacing;
     /** The {@link Paint#ascent()}. See http://www.fampennings.nl/maarten/android/08numgrid/font.png */
+
+    public float mDynamicLineSpacing = 0;
+
     private final int mFontAscent;
     /** The {@link #mFontLineSpacing} + {@link #mFontAscent}. */
     final int mFontLineSpacingAndAscent;
@@ -69,9 +72,15 @@ public final class TerminalRenderer {
         if (reverseVideo)
             canvas.drawColor(palette[TextStyle.COLOR_INDEX_FOREGROUND], PorterDuff.Mode.SRC);
 
+        if (mEmulator.mRows > 0 && canvas.getHeight() > mFontLineSpacingAndAscent) {
+            mDynamicLineSpacing = (float) (canvas.getHeight() - mFontLineSpacingAndAscent) / mEmulator.mRows;
+        } else {
+            mDynamicLineSpacing = mFontLineSpacing;
+        }
+
         float heightOffset = mFontLineSpacingAndAscent;
         for (int row = topRow; row < endRow; row++) {
-            heightOffset += mFontLineSpacing;
+            heightOffset += mDynamicLineSpacing;
 
             final int cursorX = (row == cursorRow && cursorVisible) ? cursorCol : -1;
             int selx1 = -1, selx2 = -1;
@@ -202,12 +211,13 @@ public final class TerminalRenderer {
         if (backColor != palette[TextStyle.COLOR_INDEX_BACKGROUND]) {
             // Only draw non-default background.
             mTextPaint.setColor(backColor);
-            canvas.drawRect(left, y - mFontLineSpacingAndAscent + mFontAscent, right, y, mTextPaint);
+            float top = mDynamicLineSpacing > 0 ? (y - mDynamicLineSpacing) : (y - mFontLineSpacingAndAscent + mFontAscent);
+            canvas.drawRect(left, top, right, y, mTextPaint);
         }
 
         if (cursor != 0) {
             mTextPaint.setColor(cursor);
-            float cursorHeight = mFontLineSpacingAndAscent - mFontAscent;
+            float cursorHeight = mDynamicLineSpacing > 0 ? mDynamicLineSpacing : (mFontLineSpacingAndAscent - mFontAscent);
             if (cursorStyle == TerminalEmulator.TERMINAL_CURSOR_STYLE_UNDERLINE) cursorHeight /= 4.;
             else if (cursorStyle == TerminalEmulator.TERMINAL_CURSOR_STYLE_BAR) right -= ((right - left) * 3) / 4.;
             canvas.drawRect(left, y - cursorHeight, right, y, mTextPaint);

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -545,7 +545,8 @@ public final class TerminalView extends View {
      */
     public int[] getColumnAndRow(MotionEvent event, boolean relativeToScroll) {
         int column = (int) (event.getX() / mRenderer.mFontWidth);
-        int row = (int) ((event.getY() - mRenderer.mFontLineSpacingAndAscent) / mRenderer.mFontLineSpacing);
+        float spacing = mRenderer.mDynamicLineSpacing > 0 ? mRenderer.mDynamicLineSpacing : mRenderer.mFontLineSpacing;
+        int row = (int) ((event.getY() - mRenderer.mFontLineSpacingAndAscent) / spacing);
         if (relativeToScroll) {
             row += mTopRow;
         }
@@ -1036,7 +1037,8 @@ public final class TerminalView extends View {
     }
 
     public int getCursorY(float y) {
-        return (int) (((y - 40) / mRenderer.mFontLineSpacing) + mTopRow);
+        float spacing = mRenderer.mDynamicLineSpacing > 0 ? mRenderer.mDynamicLineSpacing : mRenderer.mFontLineSpacing;
+        return (int) (((y - 40) / spacing) + mTopRow);
     }
 
     public int getPointX(int cx) {
@@ -1047,7 +1049,8 @@ public final class TerminalView extends View {
     }
 
     public int getPointY(int cy) {
-        return Math.round((cy - mTopRow) * mRenderer.mFontLineSpacing);
+        float spacing = mRenderer.mDynamicLineSpacing > 0 ? mRenderer.mDynamicLineSpacing : mRenderer.mFontLineSpacing;
+        return Math.round((cy - mTopRow) * spacing);
     }
 
     public int getTopRow() {

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -545,7 +545,7 @@ public final class TerminalView extends View {
      */
     public int[] getColumnAndRow(MotionEvent event, boolean relativeToScroll) {
         int column = (int) (event.getX() / mRenderer.mFontWidth);
-        float spacing = mRenderer.mDynamicLineSpacing > 0 ? mRenderer.mDynamicLineSpacing : mRenderer.mFontLineSpacing;
+        float spacing = mRenderer.getDynamicLineSpacing();
         int row = (int) ((event.getY() - mRenderer.mFontLineSpacingAndAscent) / spacing);
         if (relativeToScroll) {
             row += mTopRow;
@@ -1037,8 +1037,9 @@ public final class TerminalView extends View {
     }
 
     public int getCursorY(float y) {
-        float spacing = mRenderer.mDynamicLineSpacing > 0 ? mRenderer.mDynamicLineSpacing : mRenderer.mFontLineSpacing;
-        return (int) (((y - 40) / spacing) + mTopRow);
+        float spacing = mRenderer.getDynamicLineSpacing();
+        float handleOffset = mTextSelectionCursorController != null ? mTextSelectionCursorController.getHandleHeight() * 0.3f : 0;
+        return Math.round(((y - spacing + handleOffset) / spacing) + mTopRow);
     }
 
     public int getPointX(int cx) {
@@ -1049,8 +1050,7 @@ public final class TerminalView extends View {
     }
 
     public int getPointY(int cy) {
-        float spacing = mRenderer.mDynamicLineSpacing > 0 ? mRenderer.mDynamicLineSpacing : mRenderer.mFontLineSpacing;
-        return Math.round((cy - mTopRow) * spacing);
+        return Math.round((cy - mTopRow) * mRenderer.getDynamicLineSpacing());
     }
 
     public int getTopRow() {

--- a/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionCursorController.java
+++ b/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionCursorController.java
@@ -42,6 +42,10 @@ public class TextSelectionCursorController implements CursorController {
         mHandleHeight = Math.max(mStartHandle.getHandleHeight(), mEndHandle.getHandleHeight());
     }
 
+    public int getHandleHeight() {
+        return mHandleHeight;
+    }
+
     @Override
     public void show(MotionEvent event) {
         setInitialTextSelectionPosition(event);
@@ -194,8 +198,8 @@ public class TextSelectionCursorController implements CursorController {
             public void onGetContentRect(ActionMode mode, View view, Rect outRect) {
                 int x1 = Math.round(mSelX1 * terminalView.mRenderer.getFontWidth());
                 int x2 = Math.round(mSelX2 * terminalView.mRenderer.getFontWidth());
-                int y1 = Math.round((mSelY1 - 1 - terminalView.getTopRow()) * terminalView.mRenderer.getFontLineSpacing());
-                int y2 = Math.round((mSelY2 + 1 - terminalView.getTopRow()) * terminalView.mRenderer.getFontLineSpacing());
+                int y1 = Math.round((mSelY1 - 1 - terminalView.getTopRow()) * terminalView.mRenderer.getDynamicLineSpacing());
+                int y2 = Math.round((mSelY2 + 1 - terminalView.getTopRow()) * terminalView.mRenderer.getDynamicLineSpacing());
 
                 if (x1 > x2) {
                     int tmp = x1;


### PR DESCRIPTION
# Problem
Termux calculates the terminal row count by integer division:
```java
    int newRows = Math.max(4, (viewHeight - mRenderer.mFontLineSpacingAndAscent) / mRenderer.mFontLineSpacing);
```
At almost all font sizes and screen heights, (viewHeight - ascentOffset) % mFontLineSpacing yields an unused remainder of pixels (typically between 1px and 30px).
Because TerminalRenderer renders rows strictly using the integer mFontLineSpacing, this residual vertical space cannot fit another row and is left unrendered at the bottom of the viewport. This creates a persistent, visible dead space / gap beneath full-screen TUIs (e.g.Tmux statuslines if set to bottom-pos, Neovim buffers, htop) and bottom toolbars.
