### PR TITLE
Fixed Bug #5309 - Use emulator.paste() for toolbar text input in TerminalToolbarViewPager.java

### DIFF
--- a/app/src/main/java/com/termux/app/terminal/io/TerminalToolbarViewPager.java
+++ b/app/src/main/java/com/termux/app/terminal/io/TerminalToolbarViewPager.java
@@ -69,8 +69,11 @@ public class TerminalToolbarViewPager {
                     if (session != null) {
                         if (session.isRunning()) {
                             String textToSend = editText.getText().toString();
-                            if (textToSend.length() == 0) textToSend = "\r";
-                            session.write(textToSend);
+                            if (textToSend.length() == 0) {
+                                session.write("\r");
+                            } else {
+                                session.getEmulator().paste(textToSend);
+                            }
                         } else {
                             mActivity.getTermuxTerminalSessionClient().removeFinishedSession(session);
                         }


### PR DESCRIPTION
This PR fixed bug #5309 and updates the toolbar text input field  so that submitting non empty text routes through `session.getEmulator().paste(textToSend)` instead of directly calling `session.write(textToSend)`

If `textToSend` is empty (length 0), we keep `session.write("\r")`, it preserves standard "Enter" keypress semantics without wrapping an empty send in bracketed paste escape codes.

Applications that enable Bracketed Paste Mode (DECSET 2004) receive the composed text as a single paste event `\033[200~` ...  `\033[201~` rather than raw individual keystrokes. 

This eliminates per character redraw cycles and input latency in some modern reactive or component based TUIs.