### PR TITLE
Make terminal output auto-scrolling configurable

### DIFF
--- a/app/src/main/java/com/termux/app/fragments/settings/termux/TerminalViewPreferencesFragment.java
+++ b/app/src/main/java/com/termux/app/fragments/settings/termux/TerminalViewPreferencesFragment.java
@@ -57,6 +57,9 @@ class TerminalViewPreferencesDataStore extends PreferenceDataStore {
             case "terminal_margin_adjustment":
                     mPreferences.setTerminalMarginAdjustment(value);
                 break;
+            case "terminal_new_output_indicator":
+                mPreferences.setTerminalNewOutputIndicator(value);
+                break;
             default:
                 break;
         }
@@ -69,6 +72,8 @@ class TerminalViewPreferencesDataStore extends PreferenceDataStore {
         switch (key) {
             case "terminal_margin_adjustment":
                 return mPreferences.isTerminalMarginAdjustmentEnabled();
+            case "terminal_new_output_indicator":
+                return mPreferences.isTerminalNewOutputIndicatorEnabled();
             default:
                 return false;
         }

--- a/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
+++ b/app/src/main/java/com/termux/app/terminal/TermuxTerminalViewClient.java
@@ -100,6 +100,8 @@ public class TermuxTerminalViewClient extends TermuxTerminalViewClientBase {
         // Also required if user changed the preference from {@link TermuxSettings} activity and returns
         boolean isTerminalViewKeyLoggingEnabled = mActivity.getPreferences().isTerminalViewKeyLoggingEnabled();
         mActivity.getTerminalView().setIsTerminalViewKeyLoggingEnabled(isTerminalViewKeyLoggingEnabled);
+        mActivity.getTerminalView().setShowNewOutputIndicator(
+            mActivity.getPreferences().isTerminalNewOutputIndicatorEnabled());
 
         // Piggyback on the terminal view key logging toggle for now, should add a separate toggle in future
         mActivity.getTermuxActivityRootView().setIsRootViewLoggingEnabled(isTerminalViewKeyLoggingEnabled);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,11 @@
                     It should be enabled to try to fix the issue where soft keyboard covers part of extra keys/terminal view.
                     If it causes screen flickering on your devices, then disable it. (Default)</string>
 
+                <!-- Terminal View New Output Indicator -->
+                <string name="termux_terminal_view_terminal_new_output_indicator_title">Show new output indicator</string>
+                <string name="termux_terminal_view_terminal_new_output_indicator_off">New output will not show a down-arrow indicator.</string>
+                <string name="termux_terminal_view_terminal_new_output_indicator_on">New output will show a down-arrow indicator while scrolled up. (Default)</string>
+
 
 
     <!-- Termux:API App Preferences -->

--- a/app/src/main/res/xml/termux_terminal_view_preferences.xml
+++ b/app/src/main/res/xml/termux_terminal_view_preferences.xml
@@ -10,6 +10,12 @@
             app:summaryOn="@string/termux_terminal_view_terminal_margin_adjustment_on"
             app:title="@string/termux_terminal_view_terminal_margin_adjustment_title" />
 
+        <SwitchPreferenceCompat
+            app:key="terminal_new_output_indicator"
+            app:summaryOff="@string/termux_terminal_view_terminal_new_output_indicator_off"
+            app:summaryOn="@string/termux_terminal_view_terminal_new_output_indicator_on"
+            app:title="@string/termux_terminal_view_terminal_new_output_indicator_title" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -77,8 +77,12 @@ public final class TerminalView extends View {
     private boolean mNewOutputAvailable;
     private final RectF mNewOutputIndicatorBounds = new RectF();
     private final Paint mNewOutputIndicatorPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-    private ValueAnimator mNewOutputIndicatorAnimator;
-    private float mNewOutputIndicatorPulse = 1f;
+    private ValueAnimator mNewOutputIndicatorFlashAnimator;
+    private ValueAnimator mNewOutputIndicatorFadeAnimator;
+    private float mNewOutputIndicatorFlash;
+    private float mNewOutputIndicatorAlpha = 1f;
+    private boolean mNewOutputIndicatorScrolling;
+    private final Runnable mNewOutputIndicatorScrollEnd = () -> setNewOutputIndicatorScrolling(false);
     int[] mDefaultSelectors = new int[]{-1,-1,-1,-1};
 
     float mScaleFactor = 1.f;
@@ -153,6 +157,7 @@ public final class TerminalView extends View {
             @Override
             public boolean onUp(MotionEvent event) {
                 mScrollRemainder = 0.0f;
+                endNewOutputIndicatorScrolling();
                 if (mEmulator != null && mEmulator.isMouseTrackingActive() && !event.isFromSource(InputDevice.SOURCE_MOUSE) && !isSelectingText() && !scrolledWithFinger) {
                     // Quick event processing when mouse tracking is active - do not wait for check of double tapping
                     // for zooming.
@@ -188,6 +193,7 @@ public final class TerminalView extends View {
                     sendMouseEventCode(e, TerminalEmulator.MOUSE_LEFT_BUTTON_MOVED, true);
                 } else {
                     scrolledWithFinger = true;
+                    setNewOutputIndicatorScrolling(true);
                     distanceY += mScrollRemainder;
                     int deltaRows = (int) (distanceY / mRenderer.mFontLineSpacing);
                     mScrollRemainder = distanceY - deltaRows * mRenderer.mFontLineSpacing;
@@ -209,6 +215,8 @@ public final class TerminalView extends View {
                 if (mEmulator == null) return true;
                 // Do not start scrolling until last fling has been taken care of:
                 if (!mScroller.isFinished()) return true;
+
+                setNewOutputIndicatorScrolling(true);
 
                 final boolean mouseTrackingAtStartOfFling = mEmulator.isMouseTrackingActive();
                 float SCALE = 0.25f;
@@ -537,29 +545,46 @@ public final class TerminalView extends View {
 
     private void showNewOutputIndicator() {
         mNewOutputAvailable = true;
-        if (mNewOutputIndicatorAnimator == null) {
-            mNewOutputIndicatorAnimator = ValueAnimator.ofFloat(0.75f, 1f);
-            mNewOutputIndicatorAnimator.setDuration(700);
-            mNewOutputIndicatorAnimator.setRepeatCount(ValueAnimator.INFINITE);
-            mNewOutputIndicatorAnimator.setRepeatMode(ValueAnimator.REVERSE);
-            mNewOutputIndicatorAnimator.addUpdateListener(animation -> {
-                mNewOutputIndicatorPulse = (float) animation.getAnimatedValue();
+        if (mNewOutputIndicatorFlashAnimator == null) {
+            mNewOutputIndicatorFlashAnimator = ValueAnimator.ofFloat(0f, 1f, 0f);
+            mNewOutputIndicatorFlashAnimator.setDuration(100);
+            mNewOutputIndicatorFlashAnimator.addUpdateListener(animation -> {
+                mNewOutputIndicatorFlash = (float) animation.getAnimatedValue();
                 invalidate();
             });
         }
-        if (!mNewOutputIndicatorAnimator.isStarted()) mNewOutputIndicatorAnimator.start();
+        mNewOutputIndicatorFlashAnimator.cancel();
+        mNewOutputIndicatorFlashAnimator.start();
         invalidate();
     }
 
     private void clearNewOutputIndicator() {
         mNewOutputAvailable = false;
-        if (mNewOutputIndicatorAnimator != null) mNewOutputIndicatorAnimator.cancel();
-        mNewOutputIndicatorPulse = 1f;
+        if (mNewOutputIndicatorFlashAnimator != null) mNewOutputIndicatorFlashAnimator.cancel();
+        mNewOutputIndicatorFlash = 0f;
         invalidate();
     }
 
+    private void setNewOutputIndicatorScrolling(boolean scrolling) {
+        removeCallbacks(mNewOutputIndicatorScrollEnd);
+        if (mNewOutputIndicatorScrolling == scrolling) return;
+        mNewOutputIndicatorScrolling = scrolling;
+        if (mNewOutputIndicatorFadeAnimator != null) mNewOutputIndicatorFadeAnimator.cancel();
+        mNewOutputIndicatorFadeAnimator = ValueAnimator.ofFloat(mNewOutputIndicatorAlpha, scrolling ? 0f : 1f);
+        mNewOutputIndicatorFadeAnimator.setDuration(150);
+        mNewOutputIndicatorFadeAnimator.addUpdateListener(animation -> {
+            mNewOutputIndicatorAlpha = (float) animation.getAnimatedValue();
+            invalidate();
+        });
+        mNewOutputIndicatorFadeAnimator.start();
+    }
+
+    private void endNewOutputIndicatorScrolling() {
+        postDelayed(mNewOutputIndicatorScrollEnd, 150);
+    }
+
     private boolean handleNewOutputIndicatorTouch(MotionEvent event) {
-        if (!mNewOutputAvailable || !mNewOutputIndicatorBounds.contains(event.getX(), event.getY())) return false;
+        if (!mNewOutputAvailable || mNewOutputIndicatorAlpha == 0f || !mNewOutputIndicatorBounds.contains(event.getX(), event.getY())) return false;
         if (event.getAction() == MotionEvent.ACTION_UP) {
             mTopRow = 0;
             clearNewOutputIndicator();
@@ -641,6 +666,10 @@ public final class TerminalView extends View {
 
     /** Perform a scroll, either from dragging the screen or by scrolling a mouse wheel. */
     void doScroll(MotionEvent event, int rowsDown) {
+        if (rowsDown != 0) {
+            setNewOutputIndicatorScrolling(true);
+            endNewOutputIndicatorScrolling();
+        }
         boolean up = rowsDown < 0;
         int amount = Math.abs(rowsDown);
         for (int i = 0; i < amount; i++) {
@@ -678,6 +707,9 @@ public final class TerminalView extends View {
         final int action = event.getAction();
 
         if (handleNewOutputIndicatorTouch(event)) return true;
+
+        if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL)
+            endNewOutputIndicatorScrolling();
 
         if (isSelectingText()) {
             updateFloatingToolbarVisibility(event);
@@ -1063,6 +1095,7 @@ public final class TerminalView extends View {
         int newRows = Math.max(4, (viewHeight - mRenderer.mFontLineSpacingAndAscent) / mRenderer.mFontLineSpacing);
 
         if (mEmulator == null || (newColumns != mEmulator.mColumns || newRows != mEmulator.mRows)) {
+            int previousTopRow = mTopRow;
             mTermSession.updateSize(newColumns, newRows, (int) mRenderer.getFontWidth(), mRenderer.getFontLineSpacing());
             mEmulator = mTermSession.getEmulator();
             mClient.onEmulatorSet();
@@ -1071,7 +1104,8 @@ public final class TerminalView extends View {
             if (mTerminalCursorBlinkerRunnable != null)
                 mTerminalCursorBlinkerRunnable.setEmulator(mEmulator);
 
-            mTopRow = 0;
+            mTopRow = Math.max(-mEmulator.getScreen().getActiveTranscriptRows(), Math.min(0, previousTopRow));
+            if (mTopRow == 0) clearNewOutputIndicator();
             scrollTo(0, 0);
             invalidate();
         }
@@ -1097,18 +1131,20 @@ public final class TerminalView extends View {
     }
 
     private void drawNewOutputIndicator(Canvas canvas) {
-        if (!mNewOutputAvailable || isSelectingText()) return;
+        if (!mNewOutputAvailable || isSelectingText() || mNewOutputIndicatorAlpha == 0f) return;
 
         float density = getResources().getDisplayMetrics().density;
-        float radius = 20f * density * mNewOutputIndicatorPulse;
-        float centerX = getWidth() - 28f * density;
-        float centerY = getHeight() - 28f * density;
+        float radius = 20f * density;
+        float centerX = getWidth() / 2f;
+        float centerY = getHeight() / 2f;
         mNewOutputIndicatorBounds.set(centerX - 24f * density, centerY - 24f * density,
             centerX + 24f * density, centerY + 24f * density);
 
-        mNewOutputIndicatorPaint.setColor(0xDD424242);
+        int baseAlpha = 0xDD + Math.round((0xFF - 0xDD) * mNewOutputIndicatorFlash);
+        int alpha = Math.round(baseAlpha * mNewOutputIndicatorAlpha);
+        mNewOutputIndicatorPaint.setColor((alpha << 24) | 0x424242);
         canvas.drawCircle(centerX, centerY, radius, mNewOutputIndicatorPaint);
-        mNewOutputIndicatorPaint.setColor(0xFFFFFFFF);
+        mNewOutputIndicatorPaint.setColor((Math.round(0xFF * mNewOutputIndicatorAlpha) << 24) | 0xFFFFFF);
         mNewOutputIndicatorPaint.setStrokeWidth(2f * density);
         mNewOutputIndicatorPaint.setStyle(Paint.Style.STROKE);
         mNewOutputIndicatorPaint.setStrokeCap(Paint.Cap.ROUND);
@@ -1537,7 +1573,9 @@ public final class TerminalView extends View {
 
     @Override
     protected void onDetachedFromWindow() {
-        if (mNewOutputIndicatorAnimator != null) mNewOutputIndicatorAnimator.cancel();
+        removeCallbacks(mNewOutputIndicatorScrollEnd);
+        if (mNewOutputIndicatorFlashAnimator != null) mNewOutputIndicatorFlashAnimator.cancel();
+        if (mNewOutputIndicatorFadeAnimator != null) mNewOutputIndicatorFadeAnimator.cancel();
         super.onDetachedFromWindow();
 
         if (mTextSelectionCursorController != null) {

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -459,6 +459,7 @@ public final class TerminalView extends View {
 
         int rowsInHistory = mEmulator.getScreen().getActiveTranscriptRows();
         if (mTopRow < -rowsInHistory) mTopRow = -rowsInHistory;
+        boolean wasAtBottom = mTopRow == 0;
 
         if (isSelectingText() || mEmulator.isAutoScrollDisabled()) {
 
@@ -481,21 +482,28 @@ public final class TerminalView extends View {
             }
         }
 
-        if (!skipScrolling && mTopRow != 0) {
-            // Scroll down if not already there.
-            if (mTopRow < -3) {
+        if (!skipScrolling) {
+            int updatedTopRow = calculateTopRowAfterScreenUpdate(mTopRow, rowsInHistory,
+                mEmulator.getScrollCounter(), wasAtBottom);
+            if (updatedTopRow != mTopRow && Math.abs(updatedTopRow - mTopRow) > 3) {
                 // Awaken scroll bars only if scrolling a noticeable amount
                 // - we do not want visible scroll bars during normal typing
                 // of one row at a time.
                 awakenScrollBars();
             }
-            mTopRow = 0;
+            mTopRow = updatedTopRow;
         }
 
         mEmulator.clearScrollCounter();
 
         invalidate();
         if (mAccessibilityEnabled) setContentDescription(getText());
+    }
+
+    static int calculateTopRowAfterScreenUpdate(int topRow, int rowsInHistory, int rowShift, boolean wasAtBottom) {
+        int updatedTopRow = Math.max(-rowsInHistory, Math.min(0, topRow));
+        if (wasAtBottom) return 0;
+        return Math.max(-rowsInHistory, updatedTopRow - rowShift);
     }
 
     /** This must be called by the hosting activity in {@link Activity#onContextMenuClosed(Menu)}

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -1,5 +1,6 @@
 package com.termux.view;
 
+import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
@@ -7,6 +8,8 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Handler;
@@ -68,6 +71,14 @@ public final class TerminalView extends View {
 
     /** The top row of text to display. Ranges from -activeTranscriptRows to 0. */
     int mTopRow;
+
+    /** Whether a control for new output should be shown while scrolled up. */
+    private boolean mShowNewOutputIndicator;
+    private boolean mNewOutputAvailable;
+    private final RectF mNewOutputIndicatorBounds = new RectF();
+    private final Paint mNewOutputIndicatorPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private ValueAnimator mNewOutputIndicatorAnimator;
+    private float mNewOutputIndicatorPulse = 1f;
     int[] mDefaultSelectors = new int[]{-1,-1,-1,-1};
 
     float mScaleFactor = 1.f;
@@ -280,6 +291,13 @@ public final class TerminalView extends View {
         TERMINAL_VIEW_KEY_LOGGING_ENABLED = value;
     }
 
+    /** Sets whether a control for new output should be shown while scrolled up. */
+    public void setShowNewOutputIndicator(boolean value) {
+        mShowNewOutputIndicator = value;
+        if (!value) clearNewOutputIndicator();
+        else invalidate();
+    }
+
 
 
     /**
@@ -460,6 +478,7 @@ public final class TerminalView extends View {
         int rowsInHistory = mEmulator.getScreen().getActiveTranscriptRows();
         if (mTopRow < -rowsInHistory) mTopRow = -rowsInHistory;
         boolean wasAtBottom = mTopRow == 0;
+        boolean hasNewOutput = mEmulator.getScrollCounter() != 0;
 
         if (isSelectingText() || mEmulator.isAutoScrollDisabled()) {
 
@@ -494,6 +513,12 @@ public final class TerminalView extends View {
             mTopRow = updatedTopRow;
         }
 
+        if (shouldShowNewOutputIndicator(mShowNewOutputIndicator, wasAtBottom,
+            isSelectingText()) && hasNewOutput)
+            showNewOutputIndicator();
+        else if (mTopRow == 0)
+            clearNewOutputIndicator();
+
         mEmulator.clearScrollCounter();
 
         invalidate();
@@ -504,6 +529,42 @@ public final class TerminalView extends View {
         int updatedTopRow = Math.max(-rowsInHistory, Math.min(0, topRow));
         if (wasAtBottom) return 0;
         return Math.max(-rowsInHistory, updatedTopRow - rowShift);
+    }
+
+    static boolean shouldShowNewOutputIndicator(boolean enabled, boolean wasAtBottom, boolean selectingText) {
+        return enabled && !wasAtBottom && !selectingText;
+    }
+
+    private void showNewOutputIndicator() {
+        mNewOutputAvailable = true;
+        if (mNewOutputIndicatorAnimator == null) {
+            mNewOutputIndicatorAnimator = ValueAnimator.ofFloat(0.75f, 1f);
+            mNewOutputIndicatorAnimator.setDuration(700);
+            mNewOutputIndicatorAnimator.setRepeatCount(ValueAnimator.INFINITE);
+            mNewOutputIndicatorAnimator.setRepeatMode(ValueAnimator.REVERSE);
+            mNewOutputIndicatorAnimator.addUpdateListener(animation -> {
+                mNewOutputIndicatorPulse = (float) animation.getAnimatedValue();
+                invalidate();
+            });
+        }
+        if (!mNewOutputIndicatorAnimator.isStarted()) mNewOutputIndicatorAnimator.start();
+        invalidate();
+    }
+
+    private void clearNewOutputIndicator() {
+        mNewOutputAvailable = false;
+        if (mNewOutputIndicatorAnimator != null) mNewOutputIndicatorAnimator.cancel();
+        mNewOutputIndicatorPulse = 1f;
+        invalidate();
+    }
+
+    private boolean handleNewOutputIndicatorTouch(MotionEvent event) {
+        if (!mNewOutputAvailable || !mNewOutputIndicatorBounds.contains(event.getX(), event.getY())) return false;
+        if (event.getAction() == MotionEvent.ACTION_UP) {
+            mTopRow = 0;
+            clearNewOutputIndicator();
+        }
+        return true;
     }
 
     /** This must be called by the hosting activity in {@link Activity#onContextMenuClosed(Menu)}
@@ -591,6 +652,7 @@ public final class TerminalView extends View {
                 handleKeyCode(up ? KeyEvent.KEYCODE_DPAD_UP : KeyEvent.KEYCODE_DPAD_DOWN, 0);
             } else {
                 mTopRow = Math.min(0, Math.max(-(mEmulator.getScreen().getActiveTranscriptRows()), mTopRow + (up ? -1 : 1)));
+                if (mTopRow == 0) clearNewOutputIndicator();
                 if (!awakenScrollBars()) invalidate();
             }
         }
@@ -614,6 +676,8 @@ public final class TerminalView extends View {
     public boolean onTouchEvent(MotionEvent event) {
         if (mEmulator == null) return true;
         final int action = event.getAction();
+
+        if (handleNewOutputIndicatorTouch(event)) return true;
 
         if (isSelectingText()) {
             updateFloatingToolbarVisibility(event);
@@ -1029,6 +1093,30 @@ public final class TerminalView extends View {
             // render the text selection handles
             renderTextSelection();
         }
+        drawNewOutputIndicator(canvas);
+    }
+
+    private void drawNewOutputIndicator(Canvas canvas) {
+        if (!mNewOutputAvailable || isSelectingText()) return;
+
+        float density = getResources().getDisplayMetrics().density;
+        float radius = 20f * density * mNewOutputIndicatorPulse;
+        float centerX = getWidth() - 28f * density;
+        float centerY = getHeight() - 28f * density;
+        mNewOutputIndicatorBounds.set(centerX - 24f * density, centerY - 24f * density,
+            centerX + 24f * density, centerY + 24f * density);
+
+        mNewOutputIndicatorPaint.setColor(0xDD424242);
+        canvas.drawCircle(centerX, centerY, radius, mNewOutputIndicatorPaint);
+        mNewOutputIndicatorPaint.setColor(0xFFFFFFFF);
+        mNewOutputIndicatorPaint.setStrokeWidth(2f * density);
+        mNewOutputIndicatorPaint.setStyle(Paint.Style.STROKE);
+        mNewOutputIndicatorPaint.setStrokeCap(Paint.Cap.ROUND);
+        canvas.drawLine(centerX - 7f * density, centerY - 3f * density,
+            centerX, centerY + 4f * density, mNewOutputIndicatorPaint);
+        canvas.drawLine(centerX, centerY + 4f * density,
+            centerX + 7f * density, centerY - 3f * density, mNewOutputIndicatorPaint);
+        mNewOutputIndicatorPaint.setStyle(Paint.Style.FILL);
     }
 
     public TerminalSession getCurrentSession() {
@@ -1449,6 +1537,7 @@ public final class TerminalView extends View {
 
     @Override
     protected void onDetachedFromWindow() {
+        if (mNewOutputIndicatorAnimator != null) mNewOutputIndicatorAnimator.cancel();
         super.onDetachedFromWindow();
 
         if (mTextSelectionCursorController != null) {

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -547,7 +547,7 @@ public final class TerminalView extends View {
         mNewOutputAvailable = true;
         if (mNewOutputIndicatorFlashAnimator == null) {
             mNewOutputIndicatorFlashAnimator = ValueAnimator.ofFloat(0f, 1f, 0f);
-            mNewOutputIndicatorFlashAnimator.setDuration(100);
+            mNewOutputIndicatorFlashAnimator.setDuration(250);
             mNewOutputIndicatorFlashAnimator.addUpdateListener(animation -> {
                 mNewOutputIndicatorFlash = (float) animation.getAnimatedValue();
                 invalidate();
@@ -1136,13 +1136,14 @@ public final class TerminalView extends View {
         float density = getResources().getDisplayMetrics().density;
         float radius = 20f * density;
         float centerX = getWidth() / 2f;
-        float centerY = getHeight() / 2f;
+        float centerY = getHeight() - 28f * density;
         mNewOutputIndicatorBounds.set(centerX - 24f * density, centerY - 24f * density,
             centerX + 24f * density, centerY + 24f * density);
 
+        int shade = 0x42 + Math.round((0x78 - 0x42) * mNewOutputIndicatorFlash);
         int baseAlpha = 0xDD + Math.round((0xFF - 0xDD) * mNewOutputIndicatorFlash);
         int alpha = Math.round(baseAlpha * mNewOutputIndicatorAlpha);
-        mNewOutputIndicatorPaint.setColor((alpha << 24) | 0x424242);
+        mNewOutputIndicatorPaint.setColor((alpha << 24) | (shade << 16) | (shade << 8) | shade);
         canvas.drawCircle(centerX, centerY, radius, mNewOutputIndicatorPaint);
         mNewOutputIndicatorPaint.setColor((Math.round(0xFF * mNewOutputIndicatorAlpha) << 24) | 0xFFFFFF);
         mNewOutputIndicatorPaint.setStrokeWidth(2f * density);

--- a/terminal-view/src/test/java/com/termux/view/TerminalViewTest.java
+++ b/terminal-view/src/test/java/com/termux/view/TerminalViewTest.java
@@ -12,6 +12,18 @@ public class TerminalViewTest {
     }
 
     @Test
+    public void newOutputIndicatorIsShownWhenEnabledAndScrolledUp() {
+        assertEquals(true, TerminalView.shouldShowNewOutputIndicator(true, false, false));
+    }
+
+    @Test
+    public void newOutputIndicatorIsHiddenWhenDisabledOrAtBottom() {
+        assertEquals(false, TerminalView.shouldShowNewOutputIndicator(false, false, false));
+        assertEquals(false, TerminalView.shouldShowNewOutputIndicator(true, true, false));
+        assertEquals(false, TerminalView.shouldShowNewOutputIndicator(true, false, true));
+    }
+
+    @Test
     public void screenUpdatePreservesScrolledUpViewport() {
         assertEquals(-5, TerminalView.calculateTopRowAfterScreenUpdate(-2, 12, 3, false));
     }

--- a/terminal-view/src/test/java/com/termux/view/TerminalViewTest.java
+++ b/terminal-view/src/test/java/com/termux/view/TerminalViewTest.java
@@ -1,0 +1,23 @@
+package com.termux.view;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TerminalViewTest {
+
+    @Test
+    public void screenUpdateFollowsOutputWhenViewportWasAtBottom() {
+        assertEquals(0, TerminalView.calculateTopRowAfterScreenUpdate(0, 12, 3, true));
+    }
+
+    @Test
+    public void screenUpdatePreservesScrolledUpViewport() {
+        assertEquals(-5, TerminalView.calculateTopRowAfterScreenUpdate(-2, 12, 3, false));
+    }
+
+    @Test
+    public void screenUpdateClampsPreservedViewportToHistory() {
+        assertEquals(-4, TerminalView.calculateTopRowAfterScreenUpdate(-3, 4, 3, false));
+    }
+}

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxAppSharedPreferences.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxAppSharedPreferences.java
@@ -92,6 +92,14 @@ public class TermuxAppSharedPreferences extends AppSharedPreferences {
         SharedPreferenceUtils.setBoolean(mSharedPreferences, TERMUX_APP.KEY_TERMINAL_MARGIN_ADJUSTMENT, value, false);
     }
 
+    public boolean isTerminalNewOutputIndicatorEnabled() {
+        return SharedPreferenceUtils.getBoolean(mSharedPreferences, TERMUX_APP.KEY_TERMINAL_NEW_OUTPUT_INDICATOR, TERMUX_APP.DEFAULT_TERMINAL_NEW_OUTPUT_INDICATOR);
+    }
+
+    public void setTerminalNewOutputIndicator(boolean value) {
+        SharedPreferenceUtils.setBoolean(mSharedPreferences, TERMUX_APP.KEY_TERMINAL_NEW_OUTPUT_INDICATOR, value, false);
+    }
+
 
 
     public boolean isSoftKeyboardEnabled() {

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxPreferenceConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/preferences/TermuxPreferenceConstants.java
@@ -95,6 +95,10 @@ public final class TermuxPreferenceConstants {
         public static final String KEY_TERMINAL_MARGIN_ADJUSTMENT =  "terminal_margin_adjustment";
         public static final boolean DEFAULT_TERMINAL_MARGIN_ADJUSTMENT = true;
 
+        /** Defines the key for whether to show a control for new terminal output while scrolled up. */
+        public static final String KEY_TERMINAL_NEW_OUTPUT_INDICATOR = "terminal_new_output_indicator";
+        public static final boolean DEFAULT_TERMINAL_NEW_OUTPUT_INDICATOR = true;
+
 
         /**
          * Defines the key for whether to show terminal toolbar containing extra keys and text input field.


### PR DESCRIPTION
## Why this is needed

Some terminal applications, including Codex, continuously produce animated output. Under the previous behavior, every update forced the terminal viewport back to the bottom, making it effectively impossible to scroll upward and inspect earlier output. This was extremely frustrating in normal use and affects anyone using these applications in Termux.

## What changed

This PR preserves the user's scroll position when they have moved away from the bottom. When new output arrives, an optional down-arrow indicator appears and gives a single visible brightness flash. It remains available until the user clicks it or scrolls back to the bottom. Clicking it jumps to the latest output. The indicator fades while the user scrolls and returns when scrolling stops.

The indicator is controlled by Settings -> Termux -> Terminal View -> Show new output indicator and is enabled by default.

Terminal resizing, including keyboard dismissal and returning from Settings, preserves the current scroll position and clears stale output indicators when the bottom is visible.

## Validation

- `:terminal-view:test`
- `:app:assembleRelease`
- Manual verification on a Samsung Galaxy Z Flip7

The implementation is split into focused commits covering scroll preservation, indicator wiring, visual behavior, and resize handling.
